### PR TITLE
ACT-1971: Fix reference number regex for MCP server

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,9 +31,9 @@ export interface PageResponse {
 }
 
 // Regular expressions for validating reference numbers
-export const FEATURE_REF_REGEX = /^([A-Z]+)-(\d+)$/;
-export const REQUIREMENT_REF_REGEX = /^([A-Z]+)-(\d+)-(\d+)$/;
-export const NOTE_REF_REGEX = /^([A-Z]+)-N-(\d+)$/;
+export const FEATURE_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)$/;
+export const REQUIREMENT_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)-(\d+)$/;
+export const NOTE_REF_REGEX = /^([A-Z][A-Z0-9]*)-N-(\d+)$/;
 
 export interface SearchNode {
   name: string | null;


### PR DESCRIPTION
<p>The regexs used for validating record references were invalid, they did not support workspace prefixes with a number, e.g. <code>DEMO1</code>.</p>


- Support numbers in prefixes

We need to support `DEMO-1` and `DEMO1-1`, for example.