### PR TITLE
Add competitor tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+node_modules/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 node_modules/
 .env
+.claude/settings.local.json

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,7 @@ This fork currently exposes 17 MCP tools.
 Get a feature or requirement by reference.
 
 - **Required params**
-  - `reference: string`
+  - `reference_num: string`
 - **Accepted format (validated)**
   - Feature: `ABC-123`
   - Requirement: `ABC-123-1`
@@ -91,7 +91,7 @@ Get a feature or requirement by reference.
 Get an Aha! note/page by reference.
 
 - **Required params**
-  - `reference: string` (format like `ABC-N-213`)
+  - `reference_num: string` (format like `ABC-N-213`)
 - **Optional params**
   - `includeParent?: boolean` (default `false`)
 - **Backend**
@@ -133,6 +133,7 @@ List releases for a product/workspace.
   - `product_id: string`
 - **Backend**
   - REST `GET /api/v1/products/{product_id}/releases`
+  - Uses internal pagination loop to fetch all pages.
 - **Returns (summary projection)**
   - `id`, `name`, `release_date`
 
@@ -144,8 +145,9 @@ List epics for a product/workspace.
   - `product_id: string`
 - **Backend**
   - REST `GET /api/v1/products/{product_id}/epics`
+  - Uses internal pagination loop to fetch all pages.
 - **Returns (summary projection)**
-  - `reference_num`, `name`
+  - `id`, `reference_num`, `name`
 
 ### 7) `list_features`
 
@@ -155,8 +157,9 @@ List features for a product/workspace.
   - `product_id: string`
 - **Backend**
   - REST `GET /api/v1/products/{product_id}/features`
+  - Uses internal pagination loop to fetch all pages.
 - **Returns (summary projection)**
-  - `reference_num`, `name`
+  - `id`, `reference_num`, `name`
 
 ### 8) `create_epic`
 
@@ -188,8 +191,6 @@ Create a feature in a product/workspace.
   - `description?: string`
 - **Backend**
   - REST `POST /api/v1/products/{product_id}/features` with `{ feature: ... }`
-- **Important inconsistency**
-  - `release_id` is validated as required but is **not currently included** in the REST payload.
 - **Returns**
   - Full REST create response object.
 
@@ -228,7 +229,7 @@ Update a feature by reference number.
   - `goal_ids?: number[]` — links feature to goals (numeric IDs from `list_goals`)
 - **Backend**
   - REST `PUT /api/v1/features/{reference_num}` with `{ feature: ... }`
-  - `epic_id` maps to `epic_id` field in the REST payload
+  - `epic_id` maps to `epic` field in the REST payload
   - `initiative_reference_num` maps to `initiative` field in the REST payload
   - `goal_ids` maps to `goals` field in the REST payload
 - **Validation behavior**
@@ -243,12 +244,13 @@ Update an initiative by reference number.
 
 - **Required params**
   - `reference_num: string`
+  - `product_id: string`
 - **Optional params**
   - `name?: string`
   - `description?: string`
   - `goal_ids?: number[]` — links initiative to goals (numeric IDs from `list_goals`)
 - **Backend**
-  - REST `PUT /api/v1/initiatives/{reference_num}` with `{ initiative: ... }`
+  - REST `PUT /api/v1/products/{product_id}/initiatives/{reference_num}` with `{ initiative: ... }`
   - `goal_ids` maps to `goals` field in the REST payload
 - **Validation behavior**
   - Requires at least one of `name`, `description`, or `goal_ids`.
@@ -335,26 +337,24 @@ List goals for a product/workspace.
 
 These are worth knowing before making further changes:
 
-1. **Mixed identifier naming across tools**
-   - Some tools use `reference`, others use `reference_num`.
-   - This increases prompt and client complexity.
+1. **Mixed identifier naming across tools** *(resolved)*
+   - All tools now use `reference_num` consistently.
 
 2. **Mixed backend protocols (GraphQL + REST)**
    - Different error shapes, field availability, and response conventions.
+   - Accepted as-is; consolidation would require a larger refactor.
 
-3. **`create_feature` required-but-unused `release_id`**
-   - API contract and implementation are out of sync.
+3. **`create_feature` required-but-unused `release_id`** *(resolved)*
+   - `release_id` is now included in the REST payload.
 
-4. **Update validation semantics differ between feature and epic**
-   - `update_feature` uses `undefined` checks.
-   - `update_epic` uses truthy checks.
-   - Result: empty-string update behavior is inconsistent.
+4. **Update validation semantics differ between feature and epic** *(resolved)*
+   - Both `update_feature` and `update_epic` now use `undefined` checks.
 
 5. **Description formatter behavior is opinionated** *(resolved)*
    - Description formatting helper removed; create/update handlers now pass `description` through verbatim.
 
-6. **List endpoint behavior is inconsistent**
-   - Initiatives/goals fetch all pages; releases/features/epics do not currently use the same helper.
+6. **List endpoint behavior is inconsistent** *(resolved)*
+   - All list endpoints (`releases`, `features`, `epics`, `initiatives`, `goals`) now use `fetchAllPages`.
 
 7. **Tool docs lag implementation**
    - `README.md` currently documents only the original 3 tools.
@@ -367,16 +367,21 @@ These are worth knowing before making further changes:
 
 ### Open
 
-- [ ] Align create/update contracts for `release_id` and ensure `create_feature` payload includes required fields.
-- [ ] `list_features` and `list_epics` do not include `id` in their summary projections; other list tools now do.
-
-- [ ] Standardize identifier parameter naming (`reference` vs `reference_num`) or provide aliases.
-
-- [ ] Normalize list pagination behavior across all list tools.
-
 - [ ] Expand README tool documentation from 3 tools to full inventory.
 
 ### Completed
+
+- [x] **Standardize identifier parameter naming** — all tools now use `reference_num`; `get_record` and `get_page` previously used `reference`.
+
+- [x] **Fix `create_feature` payload** — `release_id` is now included in the REST body (was required by schema but silently omitted).
+
+- [x] **Normalize list pagination** — `list_releases`, `list_features`, `list_epics` now use `fetchAllPages`; consistent with `list_initiatives` and `list_goals`.
+
+- [x] **Add `id` to `list_features` and `list_epics` summaries** — projection now returns `id`, `reference_num`, `name` (aligned with other list tools).
+
+- [x] **Fix `update_initiative` endpoint** — now uses product-scoped route `/api/v1/products/{product_id}/initiatives/{reference_num}`; `product_id` added as required param.
+
+- [x] **Fix `update_feature` epic link field** — `epic_id` input now maps to `epic` field in the REST payload (API contract correction).
 
 - [x] **Support linking on `update_epic`, `update_feature`, `update_initiative`**
   - Added `initiative_reference_num` and `goal_ids` to `update_epic`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -293,8 +293,8 @@ List goals for a product/workspace.
 2. **Human-readable summary returns for list endpoints**
    - Most list tools intentionally return compact summaries instead of full payloads.
 
-3. **Problem statement formatting helper**
-   - Create/update on feature/epic applies a shared HTML formatter for descriptions to encourage structured records.
+3. **Description pass-through contract**
+   - Create/update on feature/epic passes `description` through verbatim to Aha!; callers are responsible for supplying well-formed HTML.
 
 4. **Pagination helper for some list endpoints**
    - `list_initiatives` and `list_goals` page through all results; other list endpoints currently do single-request fetches.
@@ -320,9 +320,8 @@ These are worth knowing before making further changes:
    - `update_epic` uses truthy checks.
    - Result: empty-string update behavior is inconsistent.
 
-5. **Description formatter behavior is opinionated**
-   - Auto-injects fixed HTML section structure.
-   - May be surprising for customers expecting literal pass-through text.
+5. **Description formatter behavior is opinionated** *(resolved)*
+   - Description formatting helper removed; create/update handlers now pass `description` through verbatim.
 
 6. **List endpoint behavior is inconsistent**
    - Initiatives/goals fetch all pages; releases/features/epics do not currently use the same helper.
@@ -349,15 +348,14 @@ These are worth knowing before making further changes:
 
 - [ ] Standardize identifier parameter naming (`reference` vs `reference_num`) or provide aliases.
 
-- [ ] Decide and document whether description formatting should be opt-in, opt-out, or always pass-through.
-
 - [ ] Normalize list pagination behavior across all list tools.
 
 - [ ] Expand README tool documentation from 3 tools to full inventory.
 
 ### Completed
 
-- (none yet)
+- [x] Decide and document whether description formatting should be opt-in, opt-out, or always pass-through.
+  - Resolved: description is now always passed through verbatim; formatting is the caller's responsibility.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,9 +66,9 @@ Required environment variables:
 
 ---
 
-## Current tool inventory (16 tools)
+## Current tool inventory (17 tools)
 
-This fork currently exposes 16 MCP tools.
+This fork currently exposes 17 MCP tools.
 
 > Note: parameter names are listed exactly as currently implemented.
 
@@ -101,12 +101,13 @@ Get an Aha! note/page by reference.
 
 ### 3) `search_documents`
 
-Search Aha! documents.
+Search Aha! records by full-text query.
 
 - **Required params**
   - `query: string`
 - **Optional params**
   - `searchableType?: string` (default `"Page"`)
+  - Valid values: `"Feature"`, `"Epic"`, `"Initiative"`, `"Page"`
 - **Backend**
   - GraphQL `searchDocuments` query.
   - Internally wrapped as single-item list `[searchableType]`.
@@ -201,11 +202,15 @@ Update an epic by reference number.
 - **Optional params**
   - `name?: string`
   - `description?: string`
+  - `initiative_reference_num?: string` — links epic to an initiative
+  - `goal_ids?: number[]` — links epic to goals (numeric IDs from `list_goals`)
 - **Backend**
   - REST `PUT /api/v1/epics/{reference_num}` with `{ epic: ... }`
+  - `initiative_reference_num` maps to `initiative` field in the REST payload
+  - `goal_ids` maps to `goals` field in the REST payload
 - **Validation behavior**
-  - Requires at least one of `name` or `description`.
-  - Uses truthy checks, so empty-string updates are rejected implicitly.
+  - Requires at least one of `name`, `description`, `initiative_reference_num`, or `goal_ids`.
+  - Uses `undefined` checks (aligned with `update_feature`).
 - **Returns**
   - Full REST update response object.
 
@@ -218,15 +223,40 @@ Update a feature by reference number.
 - **Optional params**
   - `name?: string`
   - `description?: string`
+  - `epic_id?: string` — links feature to an epic
+  - `initiative_reference_num?: string` — links feature to an initiative
+  - `goal_ids?: number[]` — links feature to goals (numeric IDs from `list_goals`)
 - **Backend**
   - REST `PUT /api/v1/features/{reference_num}` with `{ feature: ... }`
+  - `epic_id` maps to `epic_id` field in the REST payload
+  - `initiative_reference_num` maps to `initiative` field in the REST payload
+  - `goal_ids` maps to `goals` field in the REST payload
 - **Validation behavior**
-  - Requires at least one of `name` or `description`.
+  - Requires at least one of `name`, `description`, `epic_id`, `initiative_reference_num`, or `goal_ids`.
   - Uses `undefined` checks, so explicit empty-string fields are allowed.
 - **Returns**
   - Full REST update response object.
 
-### 12) `get_epic`
+### 12) `update_initiative`
+
+Update an initiative by reference number.
+
+- **Required params**
+  - `reference_num: string`
+- **Optional params**
+  - `name?: string`
+  - `description?: string`
+  - `goal_ids?: number[]` — links initiative to goals (numeric IDs from `list_goals`)
+- **Backend**
+  - REST `PUT /api/v1/initiatives/{reference_num}` with `{ initiative: ... }`
+  - `goal_ids` maps to `goals` field in the REST payload
+- **Validation behavior**
+  - Requires at least one of `name`, `description`, or `goal_ids`.
+  - Uses `undefined` checks.
+- **Returns**
+  - Full REST update response object.
+
+### 13) `get_epic`
 
 Get an epic by reference number.
 
@@ -237,7 +267,7 @@ Get an epic by reference number.
 - **Returns**
   - Full REST epic response object.
 
-### 13) `get_initiative`
+### 14) `get_initiative`
 
 Get an initiative by reference number.
 
@@ -248,7 +278,7 @@ Get an initiative by reference number.
 - **Returns**
   - Full REST initiative response object.
 
-### 14) `get_goal`
+### 15) `get_goal`
 
 Get a goal by reference number.
 
@@ -259,7 +289,7 @@ Get a goal by reference number.
 - **Returns**
   - Full REST goal response object.
 
-### 15) `list_initiatives`
+### 16) `list_initiatives`
 
 List initiatives for a product/workspace.
 
@@ -269,9 +299,9 @@ List initiatives for a product/workspace.
   - REST `GET /api/v1/products/{product_id}/initiatives`
   - Uses internal pagination loop to fetch all pages.
 - **Returns (summary projection)**
-  - `reference_num`, `name`
+  - `id`, `reference_num`, `name`
 
-### 16) `list_goals`
+### 17) `list_goals`
 
 List goals for a product/workspace.
 
@@ -281,7 +311,7 @@ List goals for a product/workspace.
   - REST `GET /api/v1/products/{product_id}/goals`
   - Uses internal pagination loop to fetch all pages.
 - **Returns (summary projection)**
-  - `reference_num`, `name`
+  - `id`, `reference_num`, `name`
 
 ---
 
@@ -337,14 +367,8 @@ These are worth knowing before making further changes:
 
 ### Open
 
-- [ ] **Support `initiative_reference_num` on `update_epic`**
-  - **Why:** Aha! API supports linking an epic to an initiative via `initiative_reference_num`, but this tool does not expose it yet.
-  - **Expected change:**
-    - Add optional `initiative_reference_num: string` parameter to MCP schema for `update_epic`.
-    - Pass the field through in the REST payload (`{ epic: { ... } }`).
-    - Update docs/tests accordingly.
-
 - [ ] Align create/update contracts for `release_id` and ensure `create_feature` payload includes required fields.
+- [ ] `list_features` and `list_epics` do not include `id` in their summary projections; other list tools now do.
 
 - [ ] Standardize identifier parameter naming (`reference` vs `reference_num`) or provide aliases.
 
@@ -353,6 +377,15 @@ These are worth knowing before making further changes:
 - [ ] Expand README tool documentation from 3 tools to full inventory.
 
 ### Completed
+
+- [x] **Support linking on `update_epic`, `update_feature`, `update_initiative`**
+  - Added `initiative_reference_num` and `goal_ids` to `update_epic`.
+  - Added `epic_id`, `initiative_reference_num`, and `goal_ids` to `update_feature`.
+  - Added new `update_initiative` tool with `goal_ids` support.
+  - Also fixed `update_epic` validation to use `undefined` checks (was using truthy checks, inconsistent with `update_feature`).
+
+- [x] **Document `search_documents` searchable types**
+  - `searchableType` now documents valid values: `"Feature"`, `"Epic"`, `"Initiative"`, `"Page"`.
 
 - [x] Decide and document whether description formatting should be opt-in, opt-out, or always pass-through.
   - Resolved: description is now always passed through verbatim; formatting is the caller's responsibility.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,390 @@
+# DEVELOPMENT.md
+
+## Purpose of this document
+
+This is the working reference for ongoing development of this fork of `aha-develop/aha-mcp`.
+
+The intent is to help any developer quickly understand:
+
+- what exists in this fork today,
+- why certain decisions were made,
+- where behavior is inconsistent or surprising,
+- and what should be built next.
+
+## Fork goals and guiding principles
+
+### Project goal
+
+Build a **clean, generic Aha! API MCP wrapper** that any Aha! customer can use, rather than a workspace-specific integration.
+
+### Design principles for this fork
+
+1. **Workspace-agnostic defaults**
+   - Avoid hardcoded workspace IDs, prefixes, statuses, or naming assumptions.
+   - Prefer parameters that map directly to Aha! API fields and are portable across accounts.
+
+2. **Predictable MCP tool contracts**
+   - Tool names, parameter names, and response shapes should be consistent across record types.
+   - Similar actions (e.g., `create_*`, `update_*`, `get_*`, `list_*`) should behave similarly.
+
+3. **Minimal abstraction over Aha! API semantics**
+   - Wrap Aha! APIs in a way that is easy to reason about and debug.
+   - When we transform data, it should be explicit and documented (e.g., description-to-HTML conversion).
+
+4. **Safe evolution**
+   - Prefer additive changes and deprecations over breaking renames where possible.
+   - Keep this file updated as tool behavior changes.
+
+---
+
+## Architecture snapshot
+
+### Runtime and transport
+
+- Language/runtime: TypeScript on Node.js.
+- MCP transport: stdio.
+- Entry point registers all tools in `ListToolsRequestSchema` and dispatches calls via `CallToolRequestSchema`.
+
+### API usage model
+
+The server currently uses a mixed API strategy:
+
+- **GraphQL (Aha! API v2 GraphQL endpoint)** for:
+  - `get_record`
+  - `get_page`
+  - `search_documents`
+- **REST (Aha! API v1 endpoints)** for all other tools.
+
+This split is currently practical but introduces inconsistent response shapes and field semantics.
+
+### Auth and configuration
+
+Required environment variables:
+
+- `AHA_API_TOKEN`
+- `AHA_DOMAIN` (workspace subdomain only; code constructs `https://${AHA_DOMAIN}.aha.io/...`)
+
+---
+
+## Current tool inventory (16 tools)
+
+This fork currently exposes 16 MCP tools.
+
+> Note: parameter names are listed exactly as currently implemented.
+
+### 1) `get_record`
+
+Get a feature or requirement by reference.
+
+- **Required params**
+  - `reference: string`
+- **Accepted format (validated)**
+  - Feature: `ABC-123`
+  - Requirement: `ABC-123-1`
+- **Backend**
+  - GraphQL query; tool auto-detects feature vs requirement via regex.
+- **Returns**
+  - Raw GraphQL object as pretty JSON text.
+
+### 2) `get_page`
+
+Get an Aha! note/page by reference.
+
+- **Required params**
+  - `reference: string` (format like `ABC-N-213`)
+- **Optional params**
+  - `includeParent?: boolean` (default `false`)
+- **Backend**
+  - GraphQL query with optional parent relationship inclusion.
+- **Returns**
+  - Raw GraphQL page object as pretty JSON text.
+
+### 3) `search_documents`
+
+Search Aha! documents.
+
+- **Required params**
+  - `query: string`
+- **Optional params**
+  - `searchableType?: string` (default `"Page"`)
+- **Backend**
+  - GraphQL `searchDocuments` query.
+  - Internally wrapped as single-item list `[searchableType]`.
+- **Returns**
+  - Raw GraphQL search response as pretty JSON text.
+
+### 4) `list_products`
+
+List products/workspaces visible to the API token.
+
+- **Params**
+  - none
+- **Backend**
+  - REST `GET /api/v1/products`
+- **Returns (summary projection)**
+  - `id`, `reference_prefix`, `name`
+
+### 5) `list_releases`
+
+List releases for a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+- **Backend**
+  - REST `GET /api/v1/products/{product_id}/releases`
+- **Returns (summary projection)**
+  - `id`, `name`, `release_date`
+
+### 6) `list_epics`
+
+List epics for a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+- **Backend**
+  - REST `GET /api/v1/products/{product_id}/epics`
+- **Returns (summary projection)**
+  - `reference_num`, `name`
+
+### 7) `list_features`
+
+List features for a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+- **Backend**
+  - REST `GET /api/v1/products/{product_id}/features`
+- **Returns (summary projection)**
+  - `reference_num`, `name`
+
+### 8) `create_epic`
+
+Create an epic in a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+  - `name: string`
+  - `release_id: string`
+- **Optional params**
+  - `description?: string`
+- **Backend**
+  - REST `POST /api/v1/products/{product_id}/epics` with `{ epic: ... }`
+- **Behavior note**
+  - `description` is converted into a fixed “Problem / Why this matters / Desired outcome” HTML template unless already containing `<strong>Problem</strong>`.
+- **Returns**
+  - Full REST create response object.
+
+### 9) `create_feature`
+
+Create a feature in a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+  - `name: string`
+  - `release_id: string` *(currently required by tool schema and validation)*
+- **Optional params**
+  - `epic_id?: string`
+  - `description?: string`
+- **Backend**
+  - REST `POST /api/v1/products/{product_id}/features` with `{ feature: ... }`
+- **Important inconsistency**
+  - `release_id` is validated as required but is **not currently included** in the REST payload.
+- **Returns**
+  - Full REST create response object.
+
+### 10) `update_epic`
+
+Update an epic by reference number.
+
+- **Required params**
+  - `reference_num: string`
+- **Optional params**
+  - `name?: string`
+  - `description?: string`
+- **Backend**
+  - REST `PUT /api/v1/epics/{reference_num}` with `{ epic: ... }`
+- **Validation behavior**
+  - Requires at least one of `name` or `description`.
+  - Uses truthy checks, so empty-string updates are rejected implicitly.
+- **Returns**
+  - Full REST update response object.
+
+### 11) `update_feature`
+
+Update a feature by reference number.
+
+- **Required params**
+  - `reference_num: string` (validated as feature format)
+- **Optional params**
+  - `name?: string`
+  - `description?: string`
+- **Backend**
+  - REST `PUT /api/v1/features/{reference_num}` with `{ feature: ... }`
+- **Validation behavior**
+  - Requires at least one of `name` or `description`.
+  - Uses `undefined` checks, so explicit empty-string fields are allowed.
+- **Returns**
+  - Full REST update response object.
+
+### 12) `get_epic`
+
+Get an epic by reference number.
+
+- **Required params**
+  - `reference_num: string`
+- **Backend**
+  - REST `GET /api/v1/epics/{reference_num}`
+- **Returns**
+  - Full REST epic response object.
+
+### 13) `get_initiative`
+
+Get an initiative by reference number.
+
+- **Required params**
+  - `reference_num: string`
+- **Backend**
+  - REST `GET /api/v1/initiatives/{reference_num}`
+- **Returns**
+  - Full REST initiative response object.
+
+### 14) `get_goal`
+
+Get a goal by reference number.
+
+- **Required params**
+  - `reference_num: string`
+- **Backend**
+  - REST `GET /api/v1/goals/{reference_num}`
+- **Returns**
+  - Full REST goal response object.
+
+### 15) `list_initiatives`
+
+List initiatives for a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+- **Backend**
+  - REST `GET /api/v1/products/{product_id}/initiatives`
+  - Uses internal pagination loop to fetch all pages.
+- **Returns (summary projection)**
+  - `reference_num`, `name`
+
+### 16) `list_goals`
+
+List goals for a product/workspace.
+
+- **Required params**
+  - `product_id: string`
+- **Backend**
+  - REST `GET /api/v1/products/{product_id}/goals`
+  - Uses internal pagination loop to fetch all pages.
+- **Returns (summary projection)**
+  - `reference_num`, `name`
+
+---
+
+## Key design decisions in this fork
+
+1. **Expanded tool surface via REST-first additions**
+   - Upstream had 3 tools; this fork added CRUD/read/list coverage for epics/features plus initiative/goal reads and lists.
+
+2. **Human-readable summary returns for list endpoints**
+   - Most list tools intentionally return compact summaries instead of full payloads.
+
+3. **Problem statement formatting helper**
+   - Create/update on feature/epic applies a shared HTML formatter for descriptions to encourage structured records.
+
+4. **Pagination helper for some list endpoints**
+   - `list_initiatives` and `list_goals` page through all results; other list endpoints currently do single-request fetches.
+
+---
+
+## Known inconsistencies and technical debt
+
+These are worth knowing before making further changes:
+
+1. **Mixed identifier naming across tools**
+   - Some tools use `reference`, others use `reference_num`.
+   - This increases prompt and client complexity.
+
+2. **Mixed backend protocols (GraphQL + REST)**
+   - Different error shapes, field availability, and response conventions.
+
+3. **`create_feature` required-but-unused `release_id`**
+   - API contract and implementation are out of sync.
+
+4. **Update validation semantics differ between feature and epic**
+   - `update_feature` uses `undefined` checks.
+   - `update_epic` uses truthy checks.
+   - Result: empty-string update behavior is inconsistent.
+
+5. **Description formatter behavior is opinionated**
+   - Auto-injects fixed HTML section structure.
+   - May be surprising for customers expecting literal pass-through text.
+
+6. **List endpoint behavior is inconsistent**
+   - Initiatives/goals fetch all pages; releases/features/epics do not currently use the same helper.
+
+7. **Tool docs lag implementation**
+   - `README.md` currently documents only the original 3 tools.
+
+---
+
+## Backlog (append-only)
+
+> Keep this section easy to extend. Add new items at the top with date + owner when known.
+
+### Open
+
+- [ ] **Support `initiative_reference_num` on `update_epic`**
+  - **Why:** Aha! API supports linking an epic to an initiative via `initiative_reference_num`, but this tool does not expose it yet.
+  - **Expected change:**
+    - Add optional `initiative_reference_num: string` parameter to MCP schema for `update_epic`.
+    - Pass the field through in the REST payload (`{ epic: { ... } }`).
+    - Update docs/tests accordingly.
+
+- [ ] Align create/update contracts for `release_id` and ensure `create_feature` payload includes required fields.
+
+- [ ] Standardize identifier parameter naming (`reference` vs `reference_num`) or provide aliases.
+
+- [ ] Decide and document whether description formatting should be opt-in, opt-out, or always pass-through.
+
+- [ ] Normalize list pagination behavior across all list tools.
+
+- [ ] Expand README tool documentation from 3 tools to full inventory.
+
+### Completed
+
+- (none yet)
+
+---
+
+## Suggested near-term roadmap
+
+1. **Contract consistency pass**
+   - Fix required-vs-payload mismatches and parameter naming drift.
+
+2. **Documentation parity**
+   - Keep `README.md` concise for end users and treat this file as canonical dev-level detail.
+
+3. **Low-friction quality checks**
+   - Add basic tests or schema assertions around tool registration and handler payload composition.
+
+4. **Incremental genericity checks**
+   - During every new tool addition, explicitly ask: “Would this work unchanged for an arbitrary Aha! customer?”
+
+---
+
+## Maintenance checklist for future contributors
+
+When adding or changing a tool:
+
+1. Update tool schema registration in `src/index.ts`.
+2. Update handler logic in `src/handlers.ts`.
+3. Validate required parameters match actual API payload usage.
+4. Ensure error messages are specific and record-type accurate.
+5. Update `README.md` (user-facing) and `DEVELOPMENT.md` (developer-facing).
+6. Add backlog items for known gaps discovered but not implemented.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "graphql": "^16.0.0",
-        "graphql-request": "^6.0.0"
+        "graphql-request": "^6.0.0",
+        "zod": "^4.3.6"
       },
       "bin": {
         "aha-mcp": "build/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
-        "dotenv": "^17.4.1",
-        "express": "^5.2.1",
         "graphql": "^16.0.0",
         "graphql-request": "^6.0.0"
       },
@@ -19,7 +17,6 @@
         "aha-mcp": "build/index.js"
       },
       "devDependencies": {
-        "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0"
       }
@@ -84,59 +81,6 @@
         }
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/express": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "^2"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "20.17.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.27.tgz",
@@ -145,41 +89,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -386,18 +295,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "aha-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aha-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
+        "dotenv": "^17.4.1",
+        "express": "^5.2.1",
         "graphql": "^16.0.0",
         "graphql-request": "^6.0.0"
       },
@@ -17,6 +19,7 @@
         "aha-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0"
       }
@@ -29,26 +32,110 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
-      "integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^4.1.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.27",
@@ -58,6 +145,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -73,74 +195,61 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.1.0.tgz",
-      "integrity": "sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==",
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.5.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
-      "engines": {
-        "node": ">=18"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
+        "ajv": "^8.0.0"
       },
-      "engines": {
-        "node": ">=6.0"
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
-        "supports-color": {
+        "ajv": {
           "optional": true
         }
       }
     },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -255,12 +364,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -279,14 +388,16 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
+    "node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -383,53 +494,56 @@
       }
     },
     "node_modules/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.0.1",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
-        "debug": "4.3.6",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "^2.0.0",
-        "fresh": "2.0.0",
-        "http-errors": "2.0.0",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
         "merge-descriptors": "^2.0.0",
-        "methods": "~1.1.2",
         "mime-types": "^3.0.0",
-        "on-finished": "2.4.1",
-        "once": "1.4.0",
-        "parseurl": "~1.3.3",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "router": "^2.0.0",
-        "safe-buffer": "5.2.1",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
         "send": "^1.1.0",
-        "serve-static": "^2.1.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "^2.0.0",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -437,8 +551,30 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -456,29 +592,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -601,36 +714,64 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -652,6 +793,27 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -683,15 +845,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -702,21 +855,25 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
-      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.53.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -809,18 +966,19 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -840,12 +998,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -864,25 +1022,37 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/router": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.1.0.tgz",
-      "integrity": "sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "is-promise": "^4.0.0",
         "parseurl": "^1.3.3",
         "path-to-regexp": "^8.0.0"
@@ -917,77 +1087,48 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/send": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
-      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "destroy": "^1.2.0",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
-        "fresh": "^0.5.2",
-        "http-errors": "^2.0.0",
-        "mime-types": "^2.1.35",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
-      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "parseurl": "^1.3.3",
-        "send": "^1.0.0"
+        "send": "^1.2.0"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -1036,13 +1177,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1089,9 +1230,10 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1111,9 +1253,9 @@
       "license": "MIT"
     },
     "node_modules/type-is": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
-      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -1150,15 +1292,6 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {
@@ -1208,19 +1341,21 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
-      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,13 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "dotenv": "^17.4.1",
+    "express": "^5.2.1",
     "graphql": "^16.0.0",
     "graphql-request": "^6.0.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,10 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
-    "dotenv": "^17.4.1",
-    "express": "^5.2.1",
     "graphql": "^16.0.0",
     "graphql-request": "^6.0.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "build": "tsc && chmod +x build/index.js",
+    "build": "tsc",
     "start": "node build/index.js",
     "mcp-start": "npm run build && npm run start",
     "prepublishOnly": "npm run build"
@@ -28,7 +28,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
     "graphql": "^16.0.0",
-    "graphql-request": "^6.0.0"
+    "graphql-request": "^6.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,11 +4,15 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
-  Record,
+  Record as AhaRecord,
   FeatureResponse,
   RequirementResponse,
   PageResponse,
   SearchResponse,
+  ListProductsResponse,
+  ListReleasesResponse,
+  ListFeaturesResponse,
+  ListEpicsResponse,
 } from "./types.js";
 import {
   getFeatureQuery,
@@ -18,7 +22,72 @@ import {
 } from "./queries.js";
 
 export class Handlers {
-  constructor(private client: GraphQLClient) {}
+  constructor(
+    private client: GraphQLClient,
+    private ahaDomain: string,
+    private ahaApiToken: string
+  ) {}
+
+  private async restRequest<T>(
+    path: string,
+    method: "GET" | "POST" | "PUT",
+    body?: unknown
+  ): Promise<T> {
+    const response = await fetch(`https://${this.ahaDomain}.aha.io${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.ahaApiToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Aha! REST API request failed (${response.status}): ${errorBody}`
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  private formatProblemStatementHtml(description: string): string {
+    if (/<strong>\s*Problem\s*<\/strong>/i.test(description)) {
+      return description;
+    }
+
+    const normalized = description.trim();
+    if (!normalized) {
+      return description;
+    }
+
+    const whySplit = normalized.split(/why this matters\s*:/i);
+    const desiredSplit = whySplit[1]
+      ? whySplit[1].split(/desired outcome\s*:/i)
+      : [];
+
+    const problemText = this.escapeHtml(whySplit[0]?.trim() || "");
+    const whyText = this.escapeHtml(desiredSplit[0]?.trim() || "");
+    const desiredText = this.escapeHtml(desiredSplit[1]?.trim() || "");
+
+    return [
+      "<p><strong>Problem</strong></p>",
+      `<p>${problemText}</p>`,
+      "<p><strong>Why this matters</strong></p>",
+      `<p>${whyText}</p>`,
+      "<p><strong>Desired outcome</strong></p>",
+      `<p>${desiredText}</p>`,
+    ].join("");
+  }
 
   async handleGetRecord(request: any) {
     const { reference } = request.params.arguments as { reference: string };
@@ -31,7 +100,7 @@ export class Handlers {
     }
 
     try {
-      let result: Record | undefined;
+      let result: AhaRecord | undefined;
 
       if (FEATURE_REF_REGEX.test(reference)) {
         const data = await this.client.request<FeatureResponse>(
@@ -189,4 +258,341 @@ export class Handlers {
       );
     }
   }
+
+  async handleListProducts() {
+    try {
+      const data = await this.restRequest<ListProductsResponse>(
+        "/api/v1/products",
+        "GET"
+      );
+
+      const summaries = (data.products || []).map((product) => ({
+        id: product.id,
+        reference_prefix: product.reference_prefix,
+        name: product.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list products: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListReleases(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<ListReleasesResponse>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/releases`,
+        "GET"
+      );
+
+      const summaries = (data.releases || []).map((release) => ({
+        id: release.id,
+        name: release.name,
+        release_date: release.release_date,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list releases: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListFeatures(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<ListFeaturesResponse>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/features`,
+        "GET"
+      );
+
+      const summaries = (data.features || []).map((feature) => ({
+        reference_num: feature.reference_num,
+        name: feature.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list features: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListEpics(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<ListEpicsResponse>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "GET"
+      );
+
+      const summaries = (data.epics || []).map((epic) => ({
+        reference_num: epic.reference_num,
+        name: epic.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list epics: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateEpic(request: any) {
+    const { product_id, name, release_id, description } =
+      request.params.arguments as {
+        product_id: string;
+        name: string;
+        release_id: string;
+        description?: string;
+      };
+
+    if (!product_id || !name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "product_id, name, and release_id are required"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = { name, release_id };
+    if (description) {
+      epicPayload.description = this.formatProblemStatementHtml(description);
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "POST",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateFeature(request: any) {
+    const { product_id, name, release_id, epic_id, description } =
+      request.params.arguments as {
+        product_id: string;
+        name: string;
+        release_id: string;
+        epic_id?: string;
+        description?: string;
+      };
+
+    if (!product_id || !name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "product_id, name, and release_id are required"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = { name, release_id };
+    if (epic_id) {
+      featurePayload.epic_id = epic_id;
+    }
+    if (description) {
+      featurePayload.description = this.formatProblemStatementHtml(description);
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/products/${encodeURIComponent(product_id)}/features`,
+        "POST",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateFeature(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Feature reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    if (!FEATURE_REF_REGEX.test(reference_num)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Invalid feature reference number format. Expected DEVELOP-123"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = {};
+    if (name) {
+      featurePayload.name = name;
+    }
+    if (description) {
+      featurePayload.description = this.formatProblemStatementHtml(description);
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/features/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateEpic(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Epic reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = {};
+    if (name) {
+      epicPayload.name = name;
+    }
+    if (description) {
+      epicPayload.description = this.formatProblemStatementHtml(description);
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/epics/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update epic: ${errorMessage}`
+      );
+    }
+  }
+
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -13,6 +13,8 @@ import {
   ListReleasesResponse,
   ListFeaturesResponse,
   ListEpicsResponse,
+  AhaGoalSummary,
+  AhaInitiativeSummary,
 } from "./types.js";
 import {
   getFeatureQuery,
@@ -478,11 +480,15 @@ export class Handlers {
   }
 
   async handleUpdateFeature(request: any) {
-    const { reference_num, name, description } = request.params.arguments as {
-      reference_num: string;
-      name?: string;
-      description?: string;
-    };
+    const { reference_num, name, description, epic_id, initiative_reference_num, goal_ids } =
+      request.params.arguments as {
+        reference_num: string;
+        name?: string;
+        description?: string;
+        epic_id?: string;
+        initiative_reference_num?: string;
+        goal_ids?: number[];
+      };
 
     if (!reference_num) {
       throw new McpError(
@@ -491,10 +497,16 @@ export class Handlers {
       );
     }
 
-    if (name === undefined && description === undefined) {
+    if (
+      name === undefined &&
+      description === undefined &&
+      epic_id === undefined &&
+      initiative_reference_num === undefined &&
+      goal_ids === undefined
+    ) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        "At least one of name or description must be provided"
+        "At least one of name, description, epic_id, initiative_reference_num, or goal_ids must be provided"
       );
     }
 
@@ -511,6 +523,15 @@ export class Handlers {
     }
     if (description !== undefined) {
       featurePayload.description = description;
+    }
+    if (epic_id !== undefined) {
+      featurePayload.epic_id = epic_id;
+    }
+    if (initiative_reference_num !== undefined) {
+      featurePayload.initiative = initiative_reference_num;
+    }
+    if (goal_ids !== undefined) {
+      featurePayload.goals = goal_ids;
     }
 
     try {
@@ -539,11 +560,14 @@ export class Handlers {
   }
 
   async handleUpdateEpic(request: any) {
-    const { reference_num, name, description } = request.params.arguments as {
-      reference_num: string;
-      name?: string;
-      description?: string;
-    };
+    const { reference_num, name, description, initiative_reference_num, goal_ids } =
+      request.params.arguments as {
+        reference_num: string;
+        name?: string;
+        description?: string;
+        initiative_reference_num?: string;
+        goal_ids?: number[];
+      };
 
     if (!reference_num) {
       throw new McpError(
@@ -552,19 +576,30 @@ export class Handlers {
       );
     }
 
-    if (!name && !description) {
+    if (
+      name === undefined &&
+      description === undefined &&
+      initiative_reference_num === undefined &&
+      goal_ids === undefined
+    ) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        "At least one of name or description must be provided"
+        "At least one of name, description, initiative_reference_num, or goal_ids must be provided"
       );
     }
 
     const epicPayload: { [key: string]: unknown } = {};
-    if (name) {
+    if (name !== undefined) {
       epicPayload.name = name;
     }
-    if (description) {
+    if (description !== undefined) {
       epicPayload.description = description;
+    }
+    if (initiative_reference_num !== undefined) {
+      epicPayload.initiative = initiative_reference_num;
+    }
+    if (goal_ids !== undefined) {
+      epicPayload.goals = goal_ids;
     }
 
     try {
@@ -698,12 +733,13 @@ export class Handlers {
     }
 
     try {
-      const initiatives = await this.fetchAllPages<any>(
+      const initiatives = await this.fetchAllPages<AhaInitiativeSummary>(
         `/api/v1/products/${encodeURIComponent(product_id)}/initiatives`,
         "initiatives"
       );
 
       const summaries = initiatives.map((initiative) => ({
+        id: initiative.id,
         reference_num: initiative.reference_num,
         name: initiative.name,
       }));
@@ -734,12 +770,13 @@ export class Handlers {
     }
 
     try {
-      const goals = await this.fetchAllPages<any>(
+      const goals = await this.fetchAllPages<AhaGoalSummary>(
         `/api/v1/products/${encodeURIComponent(product_id)}/goals`,
         "goals"
       );
 
       const summaries = goals.map((goal) => ({
+        id: goal.id,
         reference_num: goal.reference_num,
         name: goal.name,
       }));
@@ -753,6 +790,60 @@ export class Handlers {
       throw new McpError(
         ErrorCode.InternalError,
         `Failed to list goals: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateInitiative(request: any) {
+    const { reference_num, name, description, goal_ids } =
+      request.params.arguments as {
+        reference_num: string;
+        name?: string;
+        description?: string;
+        goal_ids?: number[];
+      };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Initiative reference_num is required"
+      );
+    }
+
+    if (name === undefined && description === undefined && goal_ids === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name, description, or goal_ids must be provided"
+      );
+    }
+
+    const initiativePayload: { [key: string]: unknown } = {};
+    if (name !== undefined) {
+      initiativePayload.name = name;
+    }
+    if (description !== undefined) {
+      initiativePayload.description = description;
+    }
+    if (goal_ids !== undefined) {
+      initiativePayload.goals = goal_ids;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/initiatives/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { initiative: initiativePayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update initiative: ${errorMessage}`
       );
     }
   }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -452,7 +452,7 @@ export class Handlers {
       );
     }
 
-    const featurePayload: { [key: string]: unknown } = { name, release_id };
+    const featurePayload: { [key: string]: unknown } = { name };
     if (epic_id) {
       featurePayload.epic_id = epic_id;
     }
@@ -494,7 +494,7 @@ export class Handlers {
       );
     }
 
-    if (!name && !description) {
+    if (name === undefined && description === undefined) {
       throw new McpError(
         ErrorCode.InvalidParams,
         "At least one of name or description must be provided"
@@ -509,10 +509,10 @@ export class Handlers {
     }
 
     const featurePayload: { [key: string]: unknown } = {};
-    if (name) {
+    if (name !== undefined) {
       featurePayload.name = name;
     }
-    if (description) {
+    if (description !== undefined) {
       featurePayload.description = this.formatProblemStatementHtml(description);
     }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1001,8 +1001,8 @@ export class Handlers {
       );
     }
 
-    // Extract product key from a reference-style input (e.g. "STU-97" → "STU")
-    const productKey = FEATURE_REF_REGEX.test(workspace_id)
+    // Extract product key from any reference-style input (e.g. "STU-97" → "STU", "STU-E-5" → "STU")
+    const productKey = workspace_id.includes("-")
       ? workspace_id.split("-")[0]
       : workspace_id;
 
@@ -1034,6 +1034,16 @@ export class Handlers {
       );
     }
 
+    // Filter by record_type using the workflow's kind field.
+    // Aha! kinds: "Feature" for features, "MasterFeature" for epics.
+    // Fall back to all workflows if kind is absent from the response.
+    const kindFilter = record_type === "feature" ? "feature" : "master";
+    const filteredWorkflows = workflows.filter((wf) => {
+      const kind: string = (wf.kind ?? "").toLowerCase();
+      return kind === "" || kind.includes(kindFilter);
+    });
+    const workflowsToProcess = filteredWorkflows.length > 0 ? filteredWorkflows : workflows;
+
     // Step 2: for each workflow, collect statuses. The list endpoint may already
     // include workflow_statuses inline; if not, fetch the workflow detail individually.
     const results: Array<{
@@ -1047,7 +1057,7 @@ export class Handlers {
       }>;
     }> = [];
 
-    for (const wf of workflows) {
+    for (const wf of workflowsToProcess) {
       let rawStatuses: any[] = Array.isArray(wf.workflow_statuses)
         ? wf.workflow_statuses
         : [];

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,11 +4,17 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
-  Record,
+  Record as AhaRecord,
   FeatureResponse,
   RequirementResponse,
   PageResponse,
   SearchResponse,
+  ListProductsResponse,
+  ListReleasesResponse,
+  ListFeaturesResponse,
+  ListEpicsResponse,
+  ListInitiativesResponse,
+  ListGoalsResponse,
 } from "./types.js";
 import {
   getFeatureQuery,
@@ -18,7 +24,78 @@ import {
 } from "./queries.js";
 
 export class Handlers {
-  constructor(private client: GraphQLClient) {}
+  constructor(
+    private client: GraphQLClient,
+    private ahaDomain: string,
+    private ahaApiToken: string
+  ) {}
+
+  private async restRequest<T>(
+    path: string,
+    method: "GET" | "POST" | "PUT",
+    body?: unknown
+  ): Promise<T> {
+    const response = await fetch(`https://${this.ahaDomain}.aha.io${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.ahaApiToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Aha! REST API request failed (${response.status}): ${errorBody}`
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private async fetchAllPages<T>(
+    path: string,
+    collectionKey: string
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+      const separator = path.includes("?") ? "&" : "?";
+      const data = await this.restRequest<any>(
+        `${path}${separator}page=${page}`,
+        "GET"
+      );
+
+      const pageItems = (data?.[collectionKey] || []) as T[];
+      results.push(...pageItems);
+
+      const pagination = data?.pagination as
+        | { total_pages?: number; current_page?: number; next_page?: number }
+        | undefined;
+
+      if (!pagination) {
+        break;
+      }
+
+      if (pagination.next_page) {
+        page = pagination.next_page;
+        continue;
+      }
+
+      if (pagination.total_pages && page < pagination.total_pages) {
+        page += 1;
+        continue;
+      }
+
+      break;
+    }
+
+    return results;
+  }
+
 
   async handleGetRecord(request: any) {
     const { reference } = request.params.arguments as { reference: string };
@@ -31,7 +108,7 @@ export class Handlers {
     }
 
     try {
-      let result: Record | undefined;
+      let result: AhaRecord | undefined;
 
       if (FEATURE_REF_REGEX.test(reference)) {
         const data = await this.client.request<FeatureResponse>(
@@ -189,4 +266,511 @@ export class Handlers {
       );
     }
   }
+
+  async handleListProducts() {
+    try {
+      const products = await this.fetchAllPages<ListProductsResponse["products"][number]>(
+        "/api/v1/products",
+        "products"
+      );
+
+      const summaries = products.map((product) => ({
+        id: product.id,
+        reference_prefix: product.reference_prefix,
+        name: product.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list products: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetEpic(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Epic reference_num is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/epics/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetInitiative(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Initiative reference_num is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/initiatives/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get initiative: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetGoal(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Goal reference_num is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/goals/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get goal: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListReleases(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const releases = await this.fetchAllPages<
+        ListReleasesResponse["releases"][number]
+      >(
+        `/api/v1/products/${encodeURIComponent(product_id)}/releases`,
+        "releases"
+      );
+
+      const summaries = releases.map((release) => ({
+        id: release.id,
+        name: release.name,
+        release_date: release.release_date,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list releases: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListFeatures(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const features = await this.fetchAllPages<
+        ListFeaturesResponse["features"][number]
+      >(
+        `/api/v1/products/${encodeURIComponent(product_id)}/features`,
+        "features"
+      );
+
+      const summaries = features.map((feature) => ({
+        reference_num: feature.reference_num,
+        name: feature.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list features: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListEpics(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const epics = await this.fetchAllPages<ListEpicsResponse["epics"][number]>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "epics"
+      );
+
+      const summaries = epics.map((epic) => ({
+        reference_num: epic.reference_num,
+        name: epic.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list epics: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListInitiatives(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const initiatives = await this.fetchAllPages<
+        ListInitiativesResponse["initiatives"][number]
+      >(
+        `/api/v1/products/${encodeURIComponent(product_id)}/initiatives`,
+        "initiatives"
+      );
+
+      const summaries = initiatives.map((initiative) => ({
+        reference_num: initiative.reference_num,
+        name: initiative.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list initiatives: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListGoals(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const goals = await this.fetchAllPages<ListGoalsResponse["goals"][number]>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/goals`,
+        "goals"
+      );
+
+      const summaries = goals.map((goal) => ({
+        reference_num: goal.reference_num,
+        name: goal.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list goals: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateEpic(request: any) {
+    const { product_id, name, release_id, description } =
+      request.params.arguments as {
+        product_id: string;
+        name: string;
+        release_id: string;
+        description?: string;
+      };
+
+    if (!product_id || !name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "product_id, name, and release_id are required"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = { name, release: release_id };
+    if (description) {
+      epicPayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "POST",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateFeature(request: any) {
+    const { name, release_id, epic_id, description } = request.params
+      .arguments as {
+      name: string;
+      release_id: string;
+      epic_id?: string;
+      description?: string;
+    };
+
+    if (!name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "name and release_id are required"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = { name, release_id };
+    if (epic_id) {
+      featurePayload.epic = epic_id;
+    }
+    if (description) {
+      featurePayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/releases/${encodeURIComponent(release_id)}/features`,
+        "POST",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateFeature(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Feature reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    if (!FEATURE_REF_REGEX.test(reference_num)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Invalid feature reference number format. Expected DEVELOP-123"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = {};
+    if (name) {
+      featurePayload.name = name;
+    }
+    if (description) {
+      featurePayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/features/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateEpic(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Epic reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = {};
+    if (name) {
+      epicPayload.name = name;
+    }
+    if (description) {
+      epicPayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/epics/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update epic: ${errorMessage}`
+      );
+    }
+  }
+
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -89,6 +89,39 @@ export class Handlers {
     ].join("");
   }
 
+  private async fetchAllPages<T>(
+    path: string,
+    key: string
+  ): Promise<T[]> {
+    const allItems: T[] = [];
+    let page = 1;
+
+    while (true) {
+      const separator = path.includes("?") ? "&" : "?";
+      const pagedPath = `${path}${separator}page=${page}`;
+      const data = await this.restRequest<any>(pagedPath, "GET");
+      const pageItems = Array.isArray(data?.[key]) ? data[key] : [];
+      allItems.push(...pageItems);
+
+      const pagination = data?.pagination;
+      if (
+        pagination &&
+        typeof pagination.current_page === "number" &&
+        typeof pagination.total_pages === "number"
+      ) {
+        if (pagination.current_page >= pagination.total_pages) {
+          break;
+        }
+      } else if (pageItems.length === 0) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return allItems;
+  }
+
   async handleGetRecord(request: any) {
     const { reference } = request.params.arguments as { reference: string };
 
@@ -591,6 +624,171 @@ export class Handlers {
       throw new McpError(
         ErrorCode.InternalError,
         `Failed to update epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetEpic(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Epic reference_num is required"
+      );
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/epics/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetInitiative(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Initiative reference_num is required"
+      );
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/initiatives/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get initiative: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetGoal(request: any) {
+    const { reference_num } = request.params.arguments as {
+      reference_num: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Goal reference_num is required"
+      );
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/goals/${encodeURIComponent(reference_num)}`,
+        "GET"
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get goal: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListInitiatives(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const initiatives = await this.fetchAllPages<any>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/initiatives`,
+        "initiatives"
+      );
+
+      const summaries = initiatives.map((initiative) => ({
+        reference_num: initiative.reference_num,
+        name: initiative.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list initiatives: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListGoals(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const goals = await this.fetchAllPages<any>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/goals`,
+        "goals"
+      );
+
+      const summaries = goals.map((goal) => ({
+        reference_num: goal.reference_num,
+        name: goal.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list goals: ${errorMessage}`
       );
     }
   }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -122,7 +122,7 @@ export class Handlers {
         return {
           content: [
             {
-              type: "text",
+              type: "text" as const,
               text: `No record found for reference ${reference_num}`,
             },
           ],
@@ -157,7 +157,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(result, null, 2),
           },
         ],
@@ -207,7 +207,7 @@ export class Handlers {
         return {
           content: [
             {
-              type: "text",
+              type: "text" as const,
               text: `No page found for reference ${reference_num}`,
             },
           ],
@@ -217,7 +217,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(data.page, null, 2),
           },
         ],
@@ -259,7 +259,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(data.searchDocuments, null, 2),
           },
         ],
@@ -293,7 +293,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -331,7 +331,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -368,7 +368,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -405,7 +405,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -446,7 +446,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -491,7 +491,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -573,7 +573,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(result, null, 2),
           },
         ],
@@ -646,7 +646,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(result, null, 2),
           },
         ],
@@ -680,7 +680,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -711,7 +711,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -742,7 +742,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -779,7 +779,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -816,7 +816,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -875,7 +875,7 @@ export class Handlers {
       }
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -924,7 +924,7 @@ export class Handlers {
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: JSON.stringify(
               { total_count: summaries.length, features: summaries },
               null,
@@ -973,7 +973,7 @@ export class Handlers {
       }));
 
       return {
-        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
       };
     } catch (error) {
       const errorMessage =
@@ -1092,7 +1092,7 @@ export class Handlers {
     return {
       content: [
         {
-          type: "text",
+          type: "text" as const,
           text: JSON.stringify(results, null, 2),
         },
       ],
@@ -1149,7 +1149,7 @@ export class Handlers {
       );
 
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {
       const errorMessage =

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,9 +4,6 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
-  Record as AhaRecord,
-  FeatureResponse,
-  RequirementResponse,
   PageResponse,
   SearchResponse,
   ListProductsResponse,
@@ -15,10 +12,10 @@ import {
   AhaEpicSummary,
   AhaGoalSummary,
   AhaInitiativeSummary,
+  AhaFeatureInReleaseSummary,
+  AhaEpicInReleaseSummary,
 } from "./types.js";
 import {
-  getFeatureQuery,
-  getRequirementQuery,
   getPageQuery,
   searchDocumentsQuery,
 } from "./queries.js";
@@ -99,22 +96,21 @@ export class Handlers {
     }
 
     try {
-      let result: AhaRecord | undefined;
+      let data: any;
+      let record: any;
 
       if (FEATURE_REF_REGEX.test(reference_num)) {
-        const data = await this.client.request<FeatureResponse>(
-          getFeatureQuery,
-          {
-            id: reference_num,
-          }
+        data = await this.restRequest<any>(
+          `/api/v1/features/${encodeURIComponent(reference_num)}?fields=*,workflow_status`,
+          "GET"
         );
-        result = data.feature;
+        record = data.feature;
       } else if (REQUIREMENT_REF_REGEX.test(reference_num)) {
-        const data = await this.client.request<RequirementResponse>(
-          getRequirementQuery,
-          { id: reference_num }
+        data = await this.restRequest<any>(
+          `/api/v1/requirements/${encodeURIComponent(reference_num)}?fields=*,workflow_status`,
+          "GET"
         );
-        result = data.requirement;
+        record = data.requirement;
       } else {
         throw new McpError(
           ErrorCode.InvalidParams,
@@ -122,7 +118,7 @@ export class Handlers {
         );
       }
 
-      if (!result) {
+      if (!record) {
         return {
           content: [
             {
@@ -130,6 +126,31 @@ export class Handlers {
               text: `No record found for reference ${reference_num}`,
             },
           ],
+        };
+      }
+
+      const result: { [key: string]: unknown } = {
+        id: record.id,
+        reference_num: record.reference_num,
+        name: record.name,
+        description: record.description?.body ?? null,
+      };
+
+      if (record.workflow_status) {
+        result.workflow_status = {
+          id: String(record.workflow_status.id),
+          name: record.workflow_status.name,
+          position: record.workflow_status.position,
+          complete: record.workflow_status.complete === true,
+          color: record.workflow_status.color ?? "",
+        };
+      }
+
+      if (record.epic) {
+        result.epic = {
+          id: record.epic.id,
+          reference_num: record.epic.reference_num,
+          name: record.epic.name,
         };
       }
 
@@ -304,6 +325,7 @@ export class Handlers {
 
       const summaries = releases.map((release) => ({
         id: release.id,
+        reference_num: release.reference_num,
         name: release.name,
         release_date: release.release_date,
       }));
@@ -482,7 +504,7 @@ export class Handlers {
   }
 
   async handleUpdateFeature(request: any) {
-    const { reference_num, name, description, epic_id, initiative_reference_num, goal_ids } =
+    const { reference_num, name, description, epic_id, initiative_reference_num, goal_ids, workflow_status } =
       request.params.arguments as {
         reference_num: string;
         name?: string;
@@ -490,6 +512,7 @@ export class Handlers {
         epic_id?: string;
         initiative_reference_num?: string;
         goal_ids?: number[];
+        workflow_status?: string;
       };
 
     if (!reference_num) {
@@ -504,11 +527,12 @@ export class Handlers {
       description === undefined &&
       epic_id === undefined &&
       initiative_reference_num === undefined &&
-      goal_ids === undefined
+      goal_ids === undefined &&
+      workflow_status === undefined
     ) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        "At least one of name, description, epic_id, initiative_reference_num, or goal_ids must be provided"
+        "At least one of name, description, epic_id, initiative_reference_num, goal_ids, or workflow_status must be provided"
       );
     }
 
@@ -534,6 +558,9 @@ export class Handlers {
     }
     if (goal_ids !== undefined) {
       featurePayload.goals = goal_ids;
+    }
+    if (workflow_status !== undefined) {
+      featurePayload.workflow_status = workflow_status;
     }
 
     try {
@@ -562,13 +589,14 @@ export class Handlers {
   }
 
   async handleUpdateEpic(request: any) {
-    const { reference_num, name, description, initiative_reference_num, goal_ids } =
+    const { reference_num, name, description, initiative_reference_num, goal_ids, workflow_status } =
       request.params.arguments as {
         reference_num: string;
         name?: string;
         description?: string;
         initiative_reference_num?: string;
         goal_ids?: number[];
+        workflow_status?: string;
       };
 
     if (!reference_num) {
@@ -582,11 +610,12 @@ export class Handlers {
       name === undefined &&
       description === undefined &&
       initiative_reference_num === undefined &&
-      goal_ids === undefined
+      goal_ids === undefined &&
+      workflow_status === undefined
     ) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        "At least one of name, description, initiative_reference_num, or goal_ids must be provided"
+        "At least one of name, description, initiative_reference_num, goal_ids, or workflow_status must be provided"
       );
     }
 
@@ -602,6 +631,9 @@ export class Handlers {
     }
     if (goal_ids !== undefined) {
       epicPayload.goals = goal_ids;
+    }
+    if (workflow_status !== undefined) {
+      epicPayload.workflow_status = { name: workflow_status };
     }
 
     try {
@@ -794,6 +826,267 @@ export class Handlers {
         `Failed to list goals: ${errorMessage}`
       );
     }
+  }
+
+  async handleGetRelease(request: any) {
+    const { release_reference_num } = request.params.arguments as {
+      release_reference_num: string;
+    };
+
+    if (!release_reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Release reference number is required"
+      );
+    }
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/releases/${encodeURIComponent(release_reference_num)}`,
+        "GET"
+      );
+      const r = data.release;
+
+      const result: Record<string, unknown> = {
+        id: r.id,
+        reference_num: r.reference_num,
+        name: r.name,
+        release_date: r.release_date,
+        development_started_on: r.development_started_on ?? null,
+        released_on: r.released_on ?? null,
+        url: r.url,
+      };
+
+      if (Array.isArray(r.release_phases) && r.release_phases.length > 0) {
+        result.release_phases = r.release_phases.map((p: any) => ({
+          id: p.id,
+          name: p.name,
+          start_on: p.start_on,
+          end_on: p.end_on,
+        }));
+      }
+
+      if (Array.isArray(r.initiatives)) {
+        result.initiatives = r.initiatives.map((i: any) => ({
+          id: i.id,
+          reference_num: i.reference_num,
+          name: i.name,
+        }));
+      }
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get release: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListFeaturesInRelease(request: any) {
+    const { release_reference_num } = request.params.arguments as {
+      release_reference_num: string;
+    };
+
+    if (!release_reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Release reference number is required"
+      );
+    }
+
+    try {
+      const features = await this.fetchAllPages<AhaFeatureInReleaseSummary>(
+        `/api/v1/releases/${encodeURIComponent(release_reference_num)}/features?per_page=200`,
+        "features"
+      );
+
+      const summaries = features.map((f) => ({
+        id: f.id,
+        reference_num: f.reference_num,
+        name: f.name,
+        workflow_status: f.workflow_status
+          ? { name: f.workflow_status.name }
+          : null,
+        epic: f.epic
+          ? { id: f.epic.id, reference_num: f.epic.reference_num, name: f.epic.name }
+          : null,
+        assigned_to_user: f.assigned_to_user
+          ? { name: f.assigned_to_user.name }
+          : null,
+        url: f.url,
+      }));
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { total_count: summaries.length, features: summaries },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list features in release: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListEpicsInRelease(request: any) {
+    const { release_reference_num } = request.params.arguments as {
+      release_reference_num: string;
+    };
+
+    if (!release_reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Release reference number is required"
+      );
+    }
+
+    try {
+      const epics = await this.fetchAllPages<AhaEpicInReleaseSummary>(
+        `/api/v1/releases/${encodeURIComponent(release_reference_num)}/master_features`,
+        "master_features"
+      );
+
+      const summaries = epics.map((e) => ({
+        id: e.id,
+        reference_num: e.reference_num,
+        name: e.name,
+        workflow_status: e.workflow_status
+          ? { name: e.workflow_status.name }
+          : null,
+        features_count: e.features_count,
+        url: e.url,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list epics in release: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListWorkflowStatuses(request: any) {
+    const { workspace_id, record_type } = request.params.arguments as {
+      workspace_id: string;
+      record_type: string;
+    };
+
+    if (!workspace_id) {
+      throw new McpError(ErrorCode.InvalidParams, "workspace_id is required");
+    }
+    if (record_type !== "feature" && record_type !== "epic") {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'record_type must be "feature" or "epic"'
+      );
+    }
+
+    // Extract product key from a reference-style input (e.g. "STU-97" → "STU")
+    const productKey = FEATURE_REF_REGEX.test(workspace_id)
+      ? workspace_id.split("-")[0]
+      : workspace_id;
+
+    // Step 1: list all workflows for the workspace
+    let workflowsData: any;
+    try {
+      workflowsData = await this.restRequest<any>(
+        `/api/v1/products/${encodeURIComponent(productKey)}/workflows`,
+        "GET"
+      );
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      const statusMatch = msg.match(/\((\d+)\)/);
+      const statusCode = statusMatch ? statusMatch[1] : "unknown";
+      throw new McpError(
+        ErrorCode.InternalError,
+        `list_workflow_statuses failed for workspace "${productKey}": API returned ${statusCode}. Check that the workspace key is correct.`
+      );
+    }
+
+    const workflows: any[] = Array.isArray(workflowsData?.workflows)
+      ? workflowsData.workflows
+      : [];
+
+    if (workflows.length === 0) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        `list_workflow_statuses failed for workspace "${productKey}": No workflows found. Check that the workspace key is correct.`
+      );
+    }
+
+    // Step 2: for each workflow, collect statuses. The list endpoint may already
+    // include workflow_statuses inline; if not, fetch the workflow detail individually.
+    const results: Array<{
+      workflow_name: string;
+      statuses: Array<{
+        id: string;
+        name: string;
+        position: number;
+        complete: boolean;
+        color: string;
+      }>;
+    }> = [];
+
+    for (const wf of workflows) {
+      let rawStatuses: any[] = Array.isArray(wf.workflow_statuses)
+        ? wf.workflow_statuses
+        : [];
+
+      if (rawStatuses.length === 0 && wf.id) {
+        try {
+          const detail = await this.restRequest<any>(
+            `/api/v1/workflows/${encodeURIComponent(wf.id)}?fields=*`,
+            "GET"
+          );
+          const detailWf = detail?.workflow ?? detail;
+          rawStatuses = Array.isArray(detailWf?.workflow_statuses)
+            ? detailWf.workflow_statuses
+            : [];
+        } catch {
+          // If the detail fetch fails, include the workflow with an empty statuses list
+        }
+      }
+
+      results.push({
+        workflow_name: wf.name,
+        statuses: rawStatuses.map((s: any) => ({
+          id: String(s.id),
+          name: s.name,
+          position: typeof s.position === "number" ? s.position : 0,
+          complete: s.complete === true,
+          color: s.color ?? "",
+        })),
+      });
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(results, null, 2),
+        },
+      ],
+    };
   }
 
   async handleUpdateInitiative(request: any) {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -29,7 +29,7 @@ export class Handlers {
 
   private async restRequest<T>(
     path: string,
-    method: "GET" | "POST" | "PUT",
+    method: "GET" | "POST" | "PUT" | "DELETE",
     body?: unknown
   ): Promise<T> {
     const response = await fetch(`https://${this.ahaDomain}.aha.io${path}`, {
@@ -49,7 +49,108 @@ export class Handlers {
       );
     }
 
+    if (response.status === 204) {
+      return {} as T;
+    }
+
     return (await response.json()) as T;
+  }
+
+  // Maps user-facing record type to the URL path segment used in the record_links API.
+  // Epics are "master_features" in the Aha! REST API's record_links paths.
+  private static readonly RECORD_TYPE_API_PATH: Record<string, string> = {
+    feature: "features",
+    epic: "master_features",
+    release: "releases",
+    idea: "ideas",
+    initiative: "initiatives",
+    page: "pages",
+    goal: "goals",
+    release_phase: "release_phases",
+    requirement: "requirements",
+  };
+
+  // Maps user-facing record type to the path used for GET resolution.
+  // Epics are resolved via /api/v1/epics/:ref (consistent with existing handlers).
+  private static readonly RECORD_TYPE_FETCH_PATH: Record<string, string> = {
+    feature: "features",
+    epic: "epics",
+    release: "releases",
+    idea: "ideas",
+    initiative: "initiatives",
+    page: "pages",
+    goal: "goals",
+    release_phase: "release_phases",
+    requirement: "requirements",
+  };
+
+  // Maps user-facing record type to the record_type string in a POST /record_links body.
+  private static readonly RECORD_TYPE_BODY: Record<string, string> = {
+    feature: "Feature",
+    epic: "MasterFeature",
+    release: "Release",
+    idea: "Idea",
+    initiative: "Initiative",
+    page: "Page",
+    goal: "Goal",
+    release_phase: "ReleasePhase",
+    requirement: "Requirement",
+  };
+
+  // Ownership hierarchy: higher index = higher order (goal is highest).
+  // Used for hierarchy inference when link_type is omitted.
+  private static readonly HIERARCHY = [
+    "requirement",
+    "feature",
+    "epic",
+    "initiative",
+    "goal",
+  ] as const;
+
+  private static readonly LINK_TYPE_LABELS: Record<number, string> = {
+    10: "Relates to",
+    20: "Depends on",
+    30: "Duplicated by",
+    40: "Contained by",
+    50: "Impacted by",
+    60: "Blocked by",
+    80: "Research for",
+  };
+
+  // Resolves a user-facing record type + reference number to the full raw API record object.
+  // The returned object always includes an `id` field.
+  private async resolveRecord(type: string, referenceNum: string): Promise<any> {
+    const fetchPath = Handlers.RECORD_TYPE_FETCH_PATH[type];
+    if (!fetchPath) {
+      throw new McpError(ErrorCode.InvalidParams, `Unsupported record type: ${type}`);
+    }
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/${fetchPath}/${encodeURIComponent(referenceNum)}?fields=*`,
+        "GET"
+      );
+      const record = data[type];
+      if (!record) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Record not found: ${type} ${referenceNum}`
+        );
+      }
+      return record;
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("(404)") || msg.includes("404")) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Record not found: ${type} ${referenceNum}`
+        );
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to resolve ${type} ${referenceNum}: ${msg}`
+      );
+    }
   }
 
   private async fetchAllPages<T>(
@@ -511,7 +612,7 @@ export class Handlers {
         description?: string;
         epic_id?: string;
         initiative_reference_num?: string;
-        goal_ids?: number[];
+        goal_ids?: string[];
         workflow_status?: string;
       };
 
@@ -595,7 +696,7 @@ export class Handlers {
         name?: string;
         description?: string;
         initiative_reference_num?: string;
-        goal_ids?: number[];
+        goal_ids?: string[];
         workflow_status?: string;
       };
 
@@ -1099,6 +1200,457 @@ export class Handlers {
     };
   }
 
+  async handleCreateRecordLink(request: any) {
+    const {
+      source_record_type,
+      source_reference_num,
+      target_record_type,
+      target_reference_num,
+      link_type: inputLinkType,
+    } = request.params.arguments as {
+      source_record_type: string;
+      source_reference_num: string;
+      target_record_type: string;
+      target_reference_num: string;
+      link_type?: number;
+    };
+
+    if (
+      !source_record_type ||
+      !source_reference_num ||
+      !target_record_type ||
+      !target_reference_num
+    ) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "source_record_type, source_reference_num, target_record_type, and target_reference_num are required"
+      );
+    }
+
+    const srcType = source_record_type.toLowerCase();
+    const tgtType = target_record_type.toLowerCase();
+
+    try {
+      // --- Ownership routing: Feature/Epic → Goal (always use field setter) ---
+      if (
+        (srcType === "feature" || srcType === "epic") &&
+        tgtType === "goal"
+      ) {
+        const goalRecord = await this.resolveRecord("goal", target_reference_num);
+        const goalId = Number(goalRecord.id);
+
+        const sourceRecord = await this.resolveRecord(srcType, source_reference_num);
+        const existingGoals: any[] = Array.isArray(sourceRecord.goals)
+          ? sourceRecord.goals
+          : [];
+        const existingGoalIds = existingGoals.map((g: any) => Number(g.id));
+
+        if (!existingGoalIds.includes(goalId)) {
+          const newGoalIds = [...existingGoalIds, goalId];
+          if (srcType === "feature") {
+            await this.restRequest(
+              `/api/v1/features/${encodeURIComponent(source_reference_num)}`,
+              "PUT",
+              { feature: { goals: newGoalIds } }
+            );
+          } else {
+            await this.restRequest(
+              `/api/v1/epics/${encodeURIComponent(source_reference_num)}`,
+              "PUT",
+              { epic: { goals: newGoalIds } }
+            );
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  mechanism: "field_setter",
+                  source: source_reference_num,
+                  target: target_reference_num,
+                  relationship: "Belongs to goal",
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // --- Ownership routing: Feature/Epic → Initiative (field setter when no link_type) ---
+      if (
+        (srcType === "feature" || srcType === "epic") &&
+        tgtType === "initiative" &&
+        inputLinkType === undefined
+      ) {
+        const sourceRecord = await this.resolveRecord(srcType, source_reference_num);
+        const existingInitiative = sourceRecord.initiative;
+
+        if (
+          existingInitiative &&
+          (existingInitiative.reference_num || existingInitiative.id)
+        ) {
+          const existingRef =
+            existingInitiative.reference_num ?? String(existingInitiative.id);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    success: false,
+                    action_required: true,
+                    message:
+                      `${source_reference_num} already belongs to initiative ${existingRef}` +
+                      ` ("${existingInitiative.name ?? existingRef}"). ` +
+                      `To replace it: call update_${srcType} with initiative_reference_num="${target_reference_num}". ` +
+                      `To add a peer "Relates to" link instead: call create_record_link again with link_type=10.`,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // No existing initiative — set via field setter
+        if (srcType === "feature") {
+          await this.restRequest(
+            `/api/v1/features/${encodeURIComponent(source_reference_num)}`,
+            "PUT",
+            { feature: { initiative: target_reference_num } }
+          );
+        } else {
+          await this.restRequest(
+            `/api/v1/epics/${encodeURIComponent(source_reference_num)}`,
+            "PUT",
+            { epic: { initiative: target_reference_num } }
+          );
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  mechanism: "field_setter",
+                  source: source_reference_num,
+                  target: target_reference_num,
+                  relationship: "Belongs to initiative",
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // --- Ownership routing: Feature/Epic → Release (field setter when no link_type) ---
+      if (
+        (srcType === "feature" || srcType === "epic") &&
+        tgtType === "release" &&
+        inputLinkType === undefined
+      ) {
+        if (srcType === "feature") {
+          await this.restRequest(
+            `/api/v1/features/${encodeURIComponent(source_reference_num)}`,
+            "PUT",
+            { feature: { release_id: target_reference_num } }
+          );
+        } else {
+          await this.restRequest(
+            `/api/v1/epics/${encodeURIComponent(source_reference_num)}`,
+            "PUT",
+            { epic: { release_id: target_reference_num } }
+          );
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  mechanism: "field_setter",
+                  source: source_reference_num,
+                  target: target_reference_num,
+                  relationship: "Belongs to release",
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // --- Ownership routing: Feature → Epic (field setter when no link_type) ---
+      if (
+        srcType === "feature" &&
+        tgtType === "epic" &&
+        inputLinkType === undefined
+      ) {
+        await this.restRequest(
+          `/api/v1/features/${encodeURIComponent(source_reference_num)}`,
+          "PUT",
+          { feature: { epic: target_reference_num } }
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  mechanism: "field_setter",
+                  source: source_reference_num,
+                  target: target_reference_num,
+                  relationship: "Belongs to epic",
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // --- Peer relationship via record_links API ---
+
+      // Same-type pairs without link_type: ask the user to specify
+      if (srcType === tgtType && inputLinkType === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  action_required: true,
+                  message:
+                    `link_type is required when linking two ${srcType} records. ` +
+                    `Valid values: 10=Relates to, 20=Depends on, 30=Duplicated by, ` +
+                    `40=Contained by, 50=Impacted by, 60=Blocked by, 80=Research for. ` +
+                    `Please call create_record_link again with the intended link_type.`,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // Hierarchy inference for cross-type pairs when link_type is omitted
+      let effectiveLinkType = inputLinkType ?? 10;
+      let effectiveSrcType = srcType;
+      let effectiveSrcRef = source_reference_num;
+      let effectiveTgtType = tgtType;
+      let effectiveTgtRef = target_reference_num;
+      let swapped = false;
+
+      if (inputLinkType === undefined) {
+        const srcOrder = (Handlers.HIERARCHY as readonly string[]).indexOf(srcType);
+        const tgtOrder = (Handlers.HIERARCHY as readonly string[]).indexOf(tgtType);
+        // If both are in the hierarchy and source is lower-order, swap
+        if (srcOrder !== -1 && tgtOrder !== -1 && srcOrder < tgtOrder) {
+          effectiveSrcType = tgtType;
+          effectiveSrcRef = target_reference_num;
+          effectiveTgtType = srcType;
+          effectiveTgtRef = source_reference_num;
+          swapped = true;
+        }
+      }
+
+      const apiPath = Handlers.RECORD_TYPE_API_PATH[effectiveSrcType];
+      if (!apiPath) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Unsupported record type: ${effectiveSrcType}`
+        );
+      }
+      const tgtBodyType = Handlers.RECORD_TYPE_BODY[effectiveTgtType];
+      if (!tgtBodyType) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Unsupported record type: ${effectiveTgtType}`
+        );
+      }
+
+      // Resolve both sides to internal IDs
+      const sourceRecord = await this.resolveRecord(effectiveSrcType, effectiveSrcRef);
+      const targetRecord = await this.resolveRecord(effectiveTgtType, effectiveTgtRef);
+
+      await this.restRequest(
+        `/api/v1/${apiPath}/${encodeURIComponent(String(sourceRecord.id))}/record_links`,
+        "POST",
+        {
+          record_link: {
+            record_type: tgtBodyType,
+            record_id: targetRecord.id,
+            link_type: effectiveLinkType,
+          },
+        }
+      );
+
+      const relationship =
+        Handlers.LINK_TYPE_LABELS[effectiveLinkType] ?? `Type ${effectiveLinkType}`;
+
+      const resultObj: Record<string, unknown> = {
+        success: true,
+        mechanism: "record_link",
+        source: effectiveSrcRef,
+        target: effectiveTgtRef,
+        relationship,
+      };
+      if (swapped) {
+        resultObj.note = `Source and target were swapped to match the Aha! ownership hierarchy (${effectiveSrcType} is higher-order than ${effectiveTgtType}).`;
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(resultObj, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("(403)")) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Permission denied creating record link: ${msg}`
+        );
+      }
+      if (msg.includes("(422)")) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Invalid link configuration (unsupported type combination or missing field): ${msg}`
+        );
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create record link: ${msg}`
+      );
+    }
+  }
+
+  async handleListRecordLinks(request: any) {
+    const { record_type, reference_num } = request.params.arguments as {
+      record_type: string;
+      reference_num: string;
+    };
+
+    if (!record_type || !reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "record_type and reference_num are required"
+      );
+    }
+
+    const apiPath = Handlers.RECORD_TYPE_API_PATH[record_type.toLowerCase()];
+    if (!apiPath) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unsupported record type: ${record_type}`
+      );
+    }
+
+    try {
+      const record = await this.resolveRecord(
+        record_type.toLowerCase(),
+        reference_num
+      );
+
+      const data = await this.restRequest<any>(
+        `/api/v1/${apiPath}/${encodeURIComponent(String(record.id))}/record_links`,
+        "GET"
+      );
+
+      const links: any[] = Array.isArray(data?.record_links)
+        ? data.record_links
+        : [];
+
+      const result = links.map((link: any) => ({
+        link_id: String(link.id ?? ""),
+        relationship:
+          link.link_type_name ??
+          Handlers.LINK_TYPE_LABELS[link.link_type] ??
+          `Type ${link.link_type}`,
+        linked_record_type: link.record?.type ?? "",
+        linked_record_reference_num: link.record?.reference_num ?? "",
+        linked_record_name: link.record?.name ?? "",
+        linked_record_status: link.record?.workflow_status?.name ?? "",
+      }));
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list record links: ${msg}`
+      );
+    }
+  }
+
+  async handleDeleteRecordLink(request: any) {
+    const { link_id } = request.params.arguments as { link_id: string };
+
+    if (!link_id) {
+      throw new McpError(ErrorCode.InvalidParams, "link_id is required");
+    }
+
+    try {
+      await this.restRequest<any>(
+        `/api/v1/record_links/${encodeURIComponent(link_id)}`,
+        "DELETE"
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ success: true, link_id }, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("(404)")) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Record link not found (link_id: ${link_id}): ${msg}`
+        );
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to delete record link: ${msg}`
+      );
+    }
+  }
+
   async handleUpdateInitiative(request: any) {
     const { reference_num, product_id, name, description, goal_ids } =
       request.params.arguments as {
@@ -1106,7 +1658,7 @@ export class Handlers {
         product_id: string;
         name?: string;
         description?: string;
-        goal_ids?: number[];
+        goal_ids?: string[];
       };
 
     if (!reference_num) {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -53,42 +53,6 @@ export class Handlers {
     return (await response.json()) as T;
   }
 
-  private escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-  }
-
-  private formatProblemStatementHtml(description: string): string {
-    if (/<strong>\s*Problem\s*<\/strong>/i.test(description)) {
-      return description;
-    }
-
-    const normalized = description.trim();
-    if (!normalized) {
-      return description;
-    }
-
-    const whySplit = normalized.split(/why this matters\s*:/i);
-    const desiredSplit = whySplit[1]
-      ? whySplit[1].split(/desired outcome\s*:/i)
-      : [];
-
-    const problemText = this.escapeHtml(whySplit[0]?.trim() || "");
-    const whyText = this.escapeHtml(desiredSplit[0]?.trim() || "");
-    const desiredText = this.escapeHtml(desiredSplit[1]?.trim() || "");
-
-    return [
-      "<p><strong>Problem</strong></p>",
-      `<p>${problemText}</p>`,
-      "<p><strong>Why this matters</strong></p>",
-      `<p>${whyText}</p>`,
-      "<p><strong>Desired outcome</strong></p>",
-      `<p>${desiredText}</p>`,
-    ].join("");
-  }
-
   private async fetchAllPages<T>(
     path: string,
     key: string
@@ -445,7 +409,7 @@ export class Handlers {
 
     const epicPayload: { [key: string]: unknown } = { name, release_id };
     if (description) {
-      epicPayload.description = this.formatProblemStatementHtml(description);
+      epicPayload.description = description;
     }
 
     try {
@@ -490,7 +454,7 @@ export class Handlers {
       featurePayload.epic_id = epic_id;
     }
     if (description) {
-      featurePayload.description = this.formatProblemStatementHtml(description);
+      featurePayload.description = description;
     }
 
     try {
@@ -546,7 +510,7 @@ export class Handlers {
       featurePayload.name = name;
     }
     if (description !== undefined) {
-      featurePayload.description = this.formatProblemStatementHtml(description);
+      featurePayload.description = description;
     }
 
     try {
@@ -600,7 +564,7 @@ export class Handlers {
       epicPayload.name = name;
     }
     if (description) {
-      epicPayload.description = this.formatProblemStatementHtml(description);
+      epicPayload.description = description;
     }
 
     try {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -86,15 +86,15 @@ export class Handlers {
 
   // Maps user-facing record type to the record_type string in a POST /record_links body.
   private static readonly RECORD_TYPE_BODY: Record<string, string> = {
-    feature: "Feature",
-    epic: "MasterFeature",
-    release: "Release",
-    idea: "Idea",
-    initiative: "Initiative",
-    page: "Page",
-    goal: "Goal",
-    release_phase: "ReleasePhase",
-    requirement: "Requirement",
+    feature: "feature",
+    epic: "epic",
+    release: "release",
+    idea: "idea",
+    initiative: "initiative",
+    page: "page",
+    goal: "goal",
+    release_phase: "release_phase",
+    requirement: "requirement",
   };
 
   // Ownership hierarchy: higher index = higher order (goal is highest).
@@ -1237,13 +1237,13 @@ export class Handlers {
         tgtType === "goal"
       ) {
         const goalRecord = await this.resolveRecord("goal", target_reference_num);
-        const goalId = Number(goalRecord.id);
+        const goalId = String(goalRecord.id);
 
         const sourceRecord = await this.resolveRecord(srcType, source_reference_num);
         const existingGoals: any[] = Array.isArray(sourceRecord.goals)
           ? sourceRecord.goals
           : [];
-        const existingGoalIds = existingGoals.map((g: any) => Number(g.id));
+        const existingGoalIds = existingGoals.map((g: any) => String(g.id));
 
         if (!existingGoalIds.includes(goalId)) {
           const newGoalIds = [...existingGoalIds, goalId];
@@ -1364,13 +1364,13 @@ export class Handlers {
           await this.restRequest(
             `/api/v1/features/${encodeURIComponent(source_reference_num)}`,
             "PUT",
-            { feature: { release_id: target_reference_num } }
+            { feature: { release: target_reference_num } }
           );
         } else {
           await this.restRequest(
             `/api/v1/epics/${encodeURIComponent(source_reference_num)}`,
             "PUT",
-            { epic: { release_id: target_reference_num } }
+            { epic: { release: target_reference_num } }
           );
         }
 
@@ -1576,7 +1576,7 @@ export class Handlers {
       );
 
       const data = await this.restRequest<any>(
-        `/api/v1/${apiPath}/${encodeURIComponent(String(record.id))}/record_links`,
+        `/api/v1/${apiPath}/${encodeURIComponent(String(record.id))}/record_links?parent_and_child_links=true`,
         "GET"
       );
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1587,22 +1587,18 @@ export class Handlers {
       );
     }
 
-    const apiPath = Handlers.RECORD_TYPE_API_PATH[record_type.toLowerCase()];
-    if (!apiPath) {
+    if (record_type.toLowerCase() !== "feature") {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Unsupported record type: ${record_type}`
+        `list_record_links only supports record_type "feature"; got "${record_type}"`
       );
     }
 
     try {
-      const record = await this.resolveRecord(
-        record_type.toLowerCase(),
-        reference_num
-      );
+      const record = await this.resolveRecord("feature", reference_num);
 
       const data = await this.restRequest<any>(
-        `/api/v1/${apiPath}/${encodeURIComponent(String(record.id))}/record_links?parent_and_child_links=true`,
+        `/api/v1/features/${encodeURIComponent(String(record.id))}/record_links?parent_and_child_links=true`,
         "GET"
       );
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1610,17 +1610,25 @@ export class Handlers {
         ? data.record_links
         : [];
 
-      const result = links.map((link: any) => ({
-        link_id: String(link.id ?? ""),
-        relationship:
-          link.link_type_name ??
-          Handlers.LINK_TYPE_LABELS[link.link_type] ??
-          `Type ${link.link_type}`,
-        linked_record_type: link.record?.type ?? "",
-        linked_record_reference_num: link.record?.reference_num ?? "",
-        linked_record_name: link.record?.name ?? "",
-        linked_record_status: link.record?.workflow_status?.name ?? "",
-      }));
+      const result = links.map((link: any) => {
+        // parent_record/child_record are the two sides; pick the one that isn't our record
+        const linkedRecord =
+          String(link.parent_record?.id) !== String(record.id)
+            ? link.parent_record
+            : link.child_record;
+        const relationship =
+          (typeof link.link_type === "string" ? link.link_type : undefined) ??
+          Handlers.LINK_TYPE_LABELS[link.link_type_id] ??
+          `Type ${link.link_type_id}`;
+        return {
+          link_id: String(link.id ?? ""),
+          relationship,
+          linked_record_type: linkedRecord?.type ?? "",
+          linked_record_reference_num: linkedRecord?.reference_num ?? "",
+          linked_record_name: linkedRecord?.name ?? "",
+          linked_record_status: linkedRecord?.workflow_status?.name ?? "",
+        };
+      });
 
       return {
         content: [

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1297,6 +1297,32 @@ export class Handlers {
         ) {
           const existingRef =
             existingInitiative.reference_num ?? String(existingInitiative.id);
+
+          // Already linked to the requested initiative — idempotent success
+          if (
+            existingRef === target_reference_num ||
+            String(existingInitiative.id) === target_reference_num
+          ) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(
+                    {
+                      success: true,
+                      mechanism: "ownership_field",
+                      source: source_reference_num,
+                      target: target_reference_num,
+                      note: `${source_reference_num} already belongs to initiative ${existingRef} — no change needed.`,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
           return {
             content: [
               {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,11 +4,15 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
-  Record,
+  Record as AhaRecord,
   FeatureResponse,
   RequirementResponse,
   PageResponse,
   SearchResponse,
+  ListProductsResponse,
+  ListReleasesResponse,
+  ListFeaturesResponse,
+  ListEpicsResponse,
 } from "./types.js";
 import {
   getFeatureQuery,
@@ -18,7 +22,78 @@ import {
 } from "./queries.js";
 
 export class Handlers {
-  constructor(private client: GraphQLClient) {}
+  constructor(
+    private client: GraphQLClient,
+    private ahaDomain: string,
+    private ahaApiToken: string
+  ) {}
+
+  private async restRequest<T>(
+    path: string,
+    method: "GET" | "POST" | "PUT",
+    body?: unknown
+  ): Promise<T> {
+    const response = await fetch(`https://${this.ahaDomain}.aha.io${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.ahaApiToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Aha! REST API request failed (${response.status}): ${errorBody}`
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private async fetchAllPages<T>(
+    path: string,
+    collectionKey: string
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+      const separator = path.includes("?") ? "&" : "?";
+      const data = await this.restRequest<any>(
+        `${path}${separator}page=${page}`,
+        "GET"
+      );
+
+      const pageItems = (data?.[collectionKey] || []) as T[];
+      results.push(...pageItems);
+
+      const pagination = data?.pagination as
+        | { total_pages?: number; current_page?: number; next_page?: number }
+        | undefined;
+
+      if (!pagination) {
+        break;
+      }
+
+      if (pagination.next_page) {
+        page = pagination.next_page;
+        continue;
+      }
+
+      if (pagination.total_pages && page < pagination.total_pages) {
+        page += 1;
+        continue;
+      }
+
+      break;
+    }
+
+    return results;
+  }
+
 
   async handleGetRecord(request: any) {
     const { reference } = request.params.arguments as { reference: string };
@@ -31,7 +106,7 @@ export class Handlers {
     }
 
     try {
-      let result: Record | undefined;
+      let result: AhaRecord | undefined;
 
       if (FEATURE_REF_REGEX.test(reference)) {
         const data = await this.client.request<FeatureResponse>(
@@ -189,4 +264,344 @@ export class Handlers {
       );
     }
   }
+
+  async handleListProducts() {
+    try {
+      const products = await this.fetchAllPages<ListProductsResponse["products"][number]>(
+        "/api/v1/products",
+        "products"
+      );
+
+      const summaries = products.map((product) => ({
+        id: product.id,
+        reference_prefix: product.reference_prefix,
+        name: product.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list products: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListReleases(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const releases = await this.fetchAllPages<
+        ListReleasesResponse["releases"][number]
+      >(
+        `/api/v1/products/${encodeURIComponent(product_id)}/releases`,
+        "releases"
+      );
+
+      const summaries = releases.map((release) => ({
+        id: release.id,
+        name: release.name,
+        release_date: release.release_date,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list releases: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListFeatures(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const features = await this.fetchAllPages<
+        ListFeaturesResponse["features"][number]
+      >(
+        `/api/v1/products/${encodeURIComponent(product_id)}/features`,
+        "features"
+      );
+
+      const summaries = features.map((feature) => ({
+        reference_num: feature.reference_num,
+        name: feature.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list features: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleListEpics(request: any) {
+    const { product_id } = request.params.arguments as {
+      product_id: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Product/workspace identifier is required"
+      );
+    }
+
+    try {
+      const epics = await this.fetchAllPages<ListEpicsResponse["epics"][number]>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "epics"
+      );
+
+      const summaries = epics.map((epic) => ({
+        reference_num: epic.reference_num,
+        name: epic.name,
+      }));
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list epics: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateEpic(request: any) {
+    const { product_id, name, release_id, description } =
+      request.params.arguments as {
+        product_id: string;
+        name: string;
+        release_id: string;
+        description?: string;
+      };
+
+    if (!product_id || !name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "product_id, name, and release_id are required"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = { name, release_id };
+    if (description) {
+      epicPayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
+        "POST",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create epic: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleCreateFeature(request: any) {
+    const { name, release_id, epic_id, description } = request.params
+      .arguments as {
+      name: string;
+      release_id: string;
+      epic_id?: string;
+      description?: string;
+    };
+
+    if (!name || !release_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "name and release_id are required"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = { name, release_id };
+    if (epic_id) {
+      featurePayload.epic_id = epic_id;
+    }
+    if (description) {
+      featurePayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/releases/${encodeURIComponent(release_id)}/features`,
+        "POST",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateFeature(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Feature reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    if (!FEATURE_REF_REGEX.test(reference_num)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Invalid feature reference number format. Expected DEVELOP-123"
+      );
+    }
+
+    const featurePayload: { [key: string]: unknown } = {};
+    if (name) {
+      featurePayload.name = name;
+    }
+    if (description) {
+      featurePayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/features/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { feature: featurePayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update feature: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleUpdateEpic(request: any) {
+    const { reference_num, name, description } = request.params.arguments as {
+      reference_num: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!reference_num) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Epic reference_num is required"
+      );
+    }
+
+    if (!name && !description) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    const epicPayload: { [key: string]: unknown } = {};
+    if (name) {
+      epicPayload.name = name;
+    }
+    if (description) {
+      epicPayload.description = description;
+    }
+
+    try {
+      const result = await this.restRequest(
+        `/api/v1/epics/${encodeURIComponent(reference_num)}`,
+        "PUT",
+        { epic: epicPayload }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update epic: ${errorMessage}`
+      );
+    }
+  }
+
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,9 +10,9 @@ import {
   PageResponse,
   SearchResponse,
   ListProductsResponse,
-  ListReleasesResponse,
-  ListFeaturesResponse,
-  ListEpicsResponse,
+  AhaReleaseSummary,
+  AhaFeatureSummary,
+  AhaEpicSummary,
   AhaGoalSummary,
   AhaInitiativeSummary,
 } from "./types.js";
@@ -89,9 +89,9 @@ export class Handlers {
   }
 
   async handleGetRecord(request: any) {
-    const { reference } = request.params.arguments as { reference: string };
+    const { reference_num } = request.params.arguments as { reference_num: string };
 
-    if (!reference) {
+    if (!reference_num) {
       throw new McpError(
         ErrorCode.InvalidParams,
         "Reference number is required"
@@ -101,18 +101,18 @@ export class Handlers {
     try {
       let result: AhaRecord | undefined;
 
-      if (FEATURE_REF_REGEX.test(reference)) {
+      if (FEATURE_REF_REGEX.test(reference_num)) {
         const data = await this.client.request<FeatureResponse>(
           getFeatureQuery,
           {
-            id: reference,
+            id: reference_num,
           }
         );
         result = data.feature;
-      } else if (REQUIREMENT_REF_REGEX.test(reference)) {
+      } else if (REQUIREMENT_REF_REGEX.test(reference_num)) {
         const data = await this.client.request<RequirementResponse>(
           getRequirementQuery,
-          { id: reference }
+          { id: reference_num }
         );
         result = data.requirement;
       } else {
@@ -127,7 +127,7 @@ export class Handlers {
           content: [
             {
               type: "text",
-              text: `No record found for reference ${reference}`,
+              text: `No record found for reference ${reference_num}`,
             },
           ],
         };
@@ -157,19 +157,19 @@ export class Handlers {
   }
 
   async handleGetPage(request: any) {
-    const { reference, includeParent = false } = request.params.arguments as {
-      reference: string;
+    const { reference_num, includeParent = false } = request.params.arguments as {
+      reference_num: string;
       includeParent?: boolean;
     };
 
-    if (!reference) {
+    if (!reference_num) {
       throw new McpError(
         ErrorCode.InvalidParams,
         "Reference number is required"
       );
     }
 
-    if (!NOTE_REF_REGEX.test(reference)) {
+    if (!NOTE_REF_REGEX.test(reference_num)) {
       throw new McpError(
         ErrorCode.InvalidParams,
         "Invalid reference number format. Expected ABC-N-213"
@@ -178,7 +178,7 @@ export class Handlers {
 
     try {
       const data = await this.client.request<PageResponse>(getPageQuery, {
-        id: reference,
+        id: reference_num,
         includeParent,
       });
 
@@ -187,7 +187,7 @@ export class Handlers {
           content: [
             {
               type: "text",
-              text: `No page found for reference ${reference}`,
+              text: `No page found for reference ${reference_num}`,
             },
           ],
         };
@@ -297,12 +297,12 @@ export class Handlers {
     }
 
     try {
-      const data = await this.restRequest<ListReleasesResponse>(
+      const releases = await this.fetchAllPages<AhaReleaseSummary>(
         `/api/v1/products/${encodeURIComponent(product_id)}/releases`,
-        "GET"
+        "releases"
       );
 
-      const summaries = (data.releases || []).map((release) => ({
+      const summaries = releases.map((release) => ({
         id: release.id,
         name: release.name,
         release_date: release.release_date,
@@ -334,12 +334,13 @@ export class Handlers {
     }
 
     try {
-      const data = await this.restRequest<ListFeaturesResponse>(
+      const features = await this.fetchAllPages<AhaFeatureSummary>(
         `/api/v1/products/${encodeURIComponent(product_id)}/features`,
-        "GET"
+        "features"
       );
 
-      const summaries = (data.features || []).map((feature) => ({
+      const summaries = features.map((feature) => ({
+        id: feature.id,
         reference_num: feature.reference_num,
         name: feature.name,
       }));
@@ -370,12 +371,13 @@ export class Handlers {
     }
 
     try {
-      const data = await this.restRequest<ListEpicsResponse>(
+      const epics = await this.fetchAllPages<AhaEpicSummary>(
         `/api/v1/products/${encodeURIComponent(product_id)}/epics`,
-        "GET"
+        "epics"
       );
 
-      const summaries = (data.epics || []).map((epic) => ({
+      const summaries = epics.map((epic) => ({
+        id: epic.id,
         reference_num: epic.reference_num,
         name: epic.name,
       }));
@@ -451,7 +453,7 @@ export class Handlers {
       );
     }
 
-    const featurePayload: { [key: string]: unknown } = { name };
+    const featurePayload: { [key: string]: unknown } = { name, release_id };
     if (epic_id) {
       featurePayload.epic_id = epic_id;
     }
@@ -525,7 +527,7 @@ export class Handlers {
       featurePayload.description = description;
     }
     if (epic_id !== undefined) {
-      featurePayload.epic_id = epic_id;
+      featurePayload.epic = epic_id;
     }
     if (initiative_reference_num !== undefined) {
       featurePayload.initiative = initiative_reference_num;
@@ -795,9 +797,10 @@ export class Handlers {
   }
 
   async handleUpdateInitiative(request: any) {
-    const { reference_num, name, description, goal_ids } =
+    const { reference_num, product_id, name, description, goal_ids } =
       request.params.arguments as {
         reference_num: string;
+        product_id: string;
         name?: string;
         description?: string;
         goal_ids?: number[];
@@ -807,6 +810,13 @@ export class Handlers {
       throw new McpError(
         ErrorCode.InvalidParams,
         "Initiative reference_num is required"
+      );
+    }
+
+    if (!product_id) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "product_id is required"
       );
     }
 
@@ -830,7 +840,7 @@ export class Handlers {
 
     try {
       const result = await this.restRequest(
-        `/api/v1/initiatives/${encodeURIComponent(reference_num)}`,
+        `/api/v1/products/${encodeURIComponent(product_id)}/initiatives/${encodeURIComponent(reference_num)}`,
         "PUT",
         { initiative: initiativePayload }
       );

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -420,7 +420,7 @@ export class Handlers {
       );
     }
 
-    const epicPayload: { [key: string]: unknown } = { name, release_id };
+    const epicPayload: { [key: string]: unknown } = { name, release: release_id };
     if (description) {
       epicPayload.description = description;
     }
@@ -463,7 +463,7 @@ export class Handlers {
 
     const featurePayload: { [key: string]: unknown } = { name, release_id };
     if (epic_id) {
-      featurePayload.epic_id = epic_id;
+      featurePayload.epic = epic_id;
     }
     if (description) {
       featurePayload.description = description;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -14,6 +14,7 @@ import {
   AhaInitiativeSummary,
   AhaFeatureInReleaseSummary,
   AhaEpicInReleaseSummary,
+  AhaCompetitorSummary,
 } from "./types.js";
 import {
   getPageQuery,
@@ -1678,6 +1679,167 @@ export class Handlers {
         ErrorCode.InternalError,
         `Failed to delete record link: ${msg}`
       );
+    }
+  }
+
+  async handleListCompetitors(request: any) {
+    const { product_id } = request.params.arguments as { product_id: string };
+
+    if (!product_id) {
+      throw new McpError(ErrorCode.InvalidParams, "product_id is required");
+    }
+
+    try {
+      const competitors = await this.fetchAllPages<AhaCompetitorSummary>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/competitors`,
+        "competitors"
+      );
+
+      const summaries = competitors.map((c) => ({
+        id: c.id,
+        reference_num: c.reference_num,
+        name: c.name,
+      }));
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(summaries, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(ErrorCode.InternalError, `Failed to list competitors: ${errorMessage}`);
+    }
+  }
+
+  async handleGetCompetitor(request: any) {
+    const { id } = request.params.arguments as { id: string };
+
+    if (!id) {
+      throw new McpError(ErrorCode.InvalidParams, "Competitor id is required");
+    }
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/competitors/${encodeURIComponent(id)}`,
+        "GET"
+      );
+      const c = data.competitor;
+
+      if (!c) {
+        return {
+          content: [{ type: "text" as const, text: `No competitor found for id ${id}` }],
+        };
+      }
+
+      const result: Record<string, unknown> = {
+        id: c.id,
+        reference_num: c.reference_num,
+        name: c.name,
+        description: c.description?.body ?? null,
+        url: c.url ?? null,
+        created_at: c.created_at ?? null,
+        updated_at: c.updated_at ?? null,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(ErrorCode.InternalError, `Failed to get competitor: ${errorMessage}`);
+    }
+  }
+
+  async handleUpdateCompetitor(request: any) {
+    const { id, name, description } = request.params.arguments as {
+      id: string;
+      name?: string;
+      description?: string;
+    };
+
+    if (!id) {
+      throw new McpError(ErrorCode.InvalidParams, "Competitor id is required");
+    }
+
+    if (name === undefined && description === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "At least one of name or description must be provided"
+      );
+    }
+
+    const payload: { [key: string]: unknown } = {};
+    if (name !== undefined) payload.name = name;
+    if (description !== undefined) payload.description = description;
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/competitors/${encodeURIComponent(id)}`,
+        "PUT",
+        { competitor: payload }
+      );
+      const c = data.competitor;
+
+      const result: Record<string, unknown> = {
+        id: c.id,
+        reference_num: c.reference_num,
+        name: c.name,
+        description: c.description?.body ?? null,
+        url: c.url ?? null,
+        created_at: c.created_at ?? null,
+        updated_at: c.updated_at ?? null,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(ErrorCode.InternalError, `Failed to update competitor: ${errorMessage}`);
+    }
+  }
+
+  async handleCreateCompetitor(request: any) {
+    const { product_id, name, description } = request.params.arguments as {
+      product_id: string;
+      name: string;
+      description?: string;
+    };
+
+    if (!product_id) {
+      throw new McpError(ErrorCode.InvalidParams, "product_id is required");
+    }
+
+    if (!name) {
+      throw new McpError(ErrorCode.InvalidParams, "name is required");
+    }
+
+    const payload: { [key: string]: unknown } = { name };
+    if (description !== undefined) payload.description = description;
+
+    try {
+      const data = await this.restRequest<any>(
+        `/api/v1/products/${encodeURIComponent(product_id)}/competitors`,
+        "POST",
+        { competitor: payload }
+      );
+      const c = data.competitor;
+
+      const result: Record<string, unknown> = {
+        id: c.id,
+        reference_num: c.reference_num,
+        name: c.name,
+        description: c.description?.body ?? null,
+        url: c.url ?? null,
+        created_at: c.created_at ?? null,
+        updated_at: c.updated_at ?? null,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new McpError(ErrorCode.InternalError, `Failed to create competitor: ${errorMessage}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,14 @@ if (!AHA_DOMAIN) {
   throw new Error("AHA_DOMAIN environment variable is required");
 }
 
+const verifiedAhaApiToken = AHA_API_TOKEN;
+const verifiedAhaDomain = AHA_DOMAIN;
+
 const client = new GraphQLClient(
-  `https://${AHA_DOMAIN}.aha.io/api/v2/graphql`,
+  `https://${verifiedAhaDomain}.aha.io/api/v2/graphql`,
   {
     headers: {
-      Authorization: `Bearer ${AHA_API_TOKEN}`,
+      Authorization: `Bearer ${verifiedAhaApiToken}`,
     },
   }
 );
@@ -47,7 +50,11 @@ class AhaMcp {
       }
     );
 
-    this.handlers = new Handlers(client);
+    this.handlers = new Handlers(
+      client,
+      verifiedAhaDomain,
+      verifiedAhaApiToken
+    );
     this.setupToolHandlers();
 
     this.server.onerror = (error) => console.error("[MCP Error]", error);
@@ -114,6 +121,235 @@ class AhaMcp {
             required: ["query"],
           },
         },
+        {
+          name: "list_products",
+          description:
+            "List Aha! workspaces/products with id, reference prefix, and name",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+        {
+          name: "get_epic",
+          description:
+            "Get an Aha! epic by reference number with top-level fields from the REST API",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Epic reference number (e.g., STU-E-66)",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "get_initiative",
+          description:
+            "Get an Aha! initiative by reference number with top-level fields from the REST API",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Initiative reference number",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "get_goal",
+          description:
+            "Get an Aha! goal by reference number with top-level fields from the REST API",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Goal reference number",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "list_releases",
+          description:
+            "List releases in an Aha! product/workspace with id, name, and release date",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_epics",
+          description:
+            "List Aha! epics in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_initiatives",
+          description:
+            "List Aha! initiatives in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_goals",
+          description:
+            "List Aha! goals in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_features",
+          description:
+            "List Aha! features in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "create_epic",
+          description:
+            "Create an Aha! epic in a product/workspace, optionally with HTML description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+              name: {
+                type: "string",
+                description: "Epic name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              description: {
+                type: "string",
+                description: "Optional description text",
+              },
+            },
+            required: ["product_id", "name", "release_id"],
+          },
+        },
+        {
+          name: "create_feature",
+          description:
+            "Create an Aha! feature in a release, optionally linked to an epic",
+          inputSchema: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                description: "Feature name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              epic_id: {
+                type: "string",
+                description: "Optional epic identifier to associate",
+              },
+              description: {
+                type: "string",
+                description: "Optional description text",
+              },
+            },
+            required: ["name", "release_id"],
+          },
+        },
+        {
+          name: "update_epic",
+          description:
+            "Update an Aha! epic by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Epic reference number",
+              },
+              name: {
+                type: "string",
+                description: "New epic name",
+              },
+              description: {
+                type: "string",
+                description: "New description text",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "update_feature",
+          description:
+            "Update an Aha! feature by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Feature reference number (e.g., DEVELOP-123)",
+              },
+              name: {
+                type: "string",
+                description: "New feature name",
+              },
+              description: {
+                type: "string",
+                description: "New description text",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
       ],
     }));
 
@@ -124,6 +360,32 @@ class AhaMcp {
         return this.handlers.handleGetPage(request);
       } else if (request.params.name === "search_documents") {
         return this.handlers.handleSearchDocuments(request);
+      } else if (request.params.name === "list_products") {
+        return this.handlers.handleListProducts();
+      } else if (request.params.name === "get_epic") {
+        return this.handlers.handleGetEpic(request);
+      } else if (request.params.name === "get_initiative") {
+        return this.handlers.handleGetInitiative(request);
+      } else if (request.params.name === "get_goal") {
+        return this.handlers.handleGetGoal(request);
+      } else if (request.params.name === "list_releases") {
+        return this.handlers.handleListReleases(request);
+      } else if (request.params.name === "list_features") {
+        return this.handlers.handleListFeatures(request);
+      } else if (request.params.name === "list_epics") {
+        return this.handlers.handleListEpics(request);
+      } else if (request.params.name === "list_initiatives") {
+        return this.handlers.handleListInitiatives(request);
+      } else if (request.params.name === "list_goals") {
+        return this.handlers.handleListGoals(request);
+      } else if (request.params.name === "create_epic") {
+        return this.handlers.handleCreateEpic(request);
+      } else if (request.params.name === "create_feature") {
+        return this.handlers.handleCreateFeature(request);
+      } else if (request.params.name === "update_epic") {
+        return this.handlers.handleUpdateEpic(request);
+      } else if (request.params.name === "update_feature") {
+        return this.handlers.handleUpdateFeature(request);
       }
 
       throw new McpError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,6 +505,72 @@ class AhaMcp {
     );
 
     this.server.registerTool(
+      "list_competitors",
+      {
+        description:
+          "List all competitor records in an Aha! workspace. Returns each competitor's numeric ID, reference number (e.g. LUM-C-1), and name. Always call this first to discover the numeric ID needed by get_competitor and update_competitor — the competitors API does not accept reference numbers for individual record access.",
+        inputSchema: {
+          product_id: z.string().describe("Workspace key (e.g. LUM)"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListCompetitors({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "get_competitor",
+      {
+        description:
+          "Get a specific Aha! competitor record by numeric ID. Returns the competitor name, full HTML description body, reference number, and timestamps. Use list_competitors first to find the numeric ID for a named competitor. Call this before update_competitor to read the current description content.",
+        inputSchema: {
+          id: z.string().describe("Numeric ID of the competitor, as returned by list_competitors"),
+        },
+      },
+      (args) =>
+        this.handlers.handleGetCompetitor({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "update_competitor",
+      {
+        description:
+          "Update an Aha! competitor record by numeric ID. Accepts a new description (raw HTML only — not markdown) and/or a new name. Returns the updated record. Use list_competitors to find the numeric ID and get_competitor to read the current state before writing. At least one of description or name must be provided.",
+        inputSchema: {
+          id: z.string().describe("Numeric ID of the competitor to update"),
+          name: z.string().optional().describe("New competitor name"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "New body content as raw HTML. Aha! stores and renders HTML directly — pass well-formed tags (e.g. <p>Text</p>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleUpdateCompetitor({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "create_competitor",
+      {
+        description:
+          "Create a new competitor record in an Aha! workspace. Requires a name and workspace product_id; accepts an optional description as raw HTML (not markdown). Returns the newly created record including its numeric ID and reference number. Use this when adding a competitor that does not yet exist in Aha! — use update_competitor instead if the record already exists.",
+        inputSchema: {
+          product_id: z.string().describe("Workspace key (e.g. LUM)"),
+          name: z.string().describe("Competitor name (e.g. Pear Deck)"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Initial body content as raw HTML. Aha! stores and renders HTML directly — pass well-formed tags (e.g. <p>Text</p>). Do not pass markdown."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleCreateCompetitor({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
       "list_workflow_statuses",
       {
         description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,14 @@ if (!AHA_DOMAIN) {
   throw new Error("AHA_DOMAIN environment variable is required");
 }
 
+const verifiedAhaApiToken = AHA_API_TOKEN;
+const verifiedAhaDomain = AHA_DOMAIN;
+
 const client = new GraphQLClient(
-  `https://${AHA_DOMAIN}.aha.io/api/v2/graphql`,
+  `https://${verifiedAhaDomain}.aha.io/api/v2/graphql`,
   {
     headers: {
-      Authorization: `Bearer ${AHA_API_TOKEN}`,
+      Authorization: `Bearer ${verifiedAhaApiToken}`,
     },
   }
 );
@@ -47,7 +50,11 @@ class AhaMcp {
       }
     );
 
-    this.handlers = new Handlers(client);
+    this.handlers = new Handlers(
+      client,
+      verifiedAhaDomain,
+      verifiedAhaApiToken
+    );
     this.setupToolHandlers();
 
     this.server.onerror = (error) => console.error("[MCP Error]", error);
@@ -114,6 +121,168 @@ class AhaMcp {
             required: ["query"],
           },
         },
+        {
+          name: "list_products",
+          description:
+            "List Aha! workspaces/products with id, reference prefix, and name",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+        {
+          name: "list_releases",
+          description:
+            "List releases in an Aha! product/workspace with id, name, and release date",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_epics",
+          description:
+            "List Aha! epics in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_features",
+          description:
+            "List Aha! features in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "create_epic",
+          description:
+            "Create an Aha! epic in a product/workspace, optionally with HTML description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+              name: {
+                type: "string",
+                description: "Epic name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              description: {
+                type: "string",
+                description:
+                  "Optional problem statement text; converted to simple HTML sections",
+              },
+            },
+            required: ["product_id", "name", "release_id"],
+          },
+        },
+        {
+          name: "create_feature",
+          description:
+            "Create an Aha! feature in a product/workspace, optionally linked to an epic and with HTML description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+              name: {
+                type: "string",
+                description: "Feature name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              epic_id: {
+                type: "string",
+                description: "Optional epic identifier to associate",
+              },
+              description: {
+                type: "string",
+                description:
+                  "Optional problem statement text; converted to simple HTML sections",
+              },
+            },
+            required: ["product_id", "name", "release_id"],
+          },
+        },
+        {
+          name: "update_epic",
+          description:
+            "Update an Aha! epic by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Epic reference number",
+              },
+              name: {
+                type: "string",
+                description: "New epic name",
+              },
+              description: {
+                type: "string",
+                description:
+                  "New problem statement text; converted to simple HTML sections",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "update_feature",
+          description:
+            "Update an Aha! feature by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Feature reference number (e.g., DEVELOP-123)",
+              },
+              name: {
+                type: "string",
+                description: "New feature name",
+              },
+              description: {
+                type: "string",
+                description:
+                  "New problem statement text; converted to simple HTML sections",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
       ],
     }));
 
@@ -124,6 +293,22 @@ class AhaMcp {
         return this.handlers.handleGetPage(request);
       } else if (request.params.name === "search_documents") {
         return this.handlers.handleSearchDocuments(request);
+      } else if (request.params.name === "list_products") {
+        return this.handlers.handleListProducts();
+      } else if (request.params.name === "list_releases") {
+        return this.handlers.handleListReleases(request);
+      } else if (request.params.name === "list_features") {
+        return this.handlers.handleListFeatures(request);
+      } else if (request.params.name === "list_epics") {
+        return this.handlers.handleListEpics(request);
+      } else if (request.params.name === "create_epic") {
+        return this.handlers.handleCreateEpic(request);
+      } else if (request.params.name === "create_feature") {
+        return this.handlers.handleCreateFeature(request);
+      } else if (request.params.name === "update_epic") {
+        return this.handlers.handleUpdateEpic(request);
+      } else if (request.params.name === "update_feature") {
+        return this.handlers.handleUpdateFeature(request);
       }
 
       throw new McpError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ class AhaMcp {
               description: {
                 type: "string",
                 description:
-                  "Optional problem statement text; converted to simple HTML sections",
+                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
               },
             },
             required: ["product_id", "name", "release_id"],
@@ -229,7 +229,7 @@ class AhaMcp {
               description: {
                 type: "string",
                 description:
-                  "Optional problem statement text; converted to simple HTML sections",
+                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
               },
             },
             required: ["product_id", "name", "release_id"],
@@ -253,7 +253,7 @@ class AhaMcp {
               description: {
                 type: "string",
                 description:
-                  "New problem statement text; converted to simple HTML sections",
+                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
               },
             },
             required: ["reference_num"],
@@ -277,7 +277,7 @@ class AhaMcp {
               description: {
                 type: "string",
                 description:
-                  "New problem statement text; converted to simple HTML sections",
+                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
               },
             },
             required: ["reference_num"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListToolsRequestSchema,
-  McpError,
-} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 import { GraphQLClient } from "graphql-request";
 import { Handlers } from "./handlers.js";
 
@@ -34,11 +29,11 @@ const client = new GraphQLClient(
 );
 
 class AhaMcp {
-  private server: Server;
+  private server: McpServer;
   private handlers: Handlers;
 
   constructor() {
-    this.server = new Server(
+    this.server = new McpServer(
       {
         name: "aha-mcp",
         version: "1.1.0",
@@ -57,496 +52,408 @@ class AhaMcp {
     );
     this.setupToolHandlers();
 
-    this.server.onerror = (error) => console.error("[MCP Error]", error);
+    this.server.server.onerror = (error) => console.error("[MCP Error]", error);
     process.on("SIGINT", async () => {
-      await this.server.close();
+      await this.server.server.close();
       process.exit(0);
     });
   }
 
   private setupToolHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: "get_record",
-          description: "Get an Aha! feature or requirement by reference number. Returns name, description, workflow status (name, complete flag), and linked epic. Use this to read current feature state before updating, or to confirm status after a update_feature call. For epics, use get_epic instead.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description:
-                  "Reference number (e.g., DEVELOP-123 or ADT-123-1)",
-              },
-            },
-            required: ["reference_num"],
-          },
+    this.server.registerTool(
+      "get_record",
+      {
+        description:
+          "Get an Aha! feature or requirement by reference number. Returns name, description, workflow status (name, complete flag), and linked epic. Use this to read current feature state before updating, or to confirm status after a update_feature call. For epics, use get_epic instead.",
+        inputSchema: {
+          reference_num: z
+            .string()
+            .describe("Reference number (e.g., DEVELOP-123 or ADT-123-1)"),
         },
-        {
-          name: "get_page",
-          description:
-            "Get an Aha! page by reference number with optional relationships",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Reference number (e.g., ABC-N-213)",
-              },
-              includeParent: {
-                type: "boolean",
-                description: "Include parent page in the response",
-                default: false,
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "search_documents",
-          description:
-            "Search Aha! records by full-text query across features, epics, initiatives, or pages",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: {
-                type: "string",
-                description: "Search query string",
-              },
-              searchableType: {
-                type: "string",
-                description:
-                  'Type of record to search. Valid values: "Feature", "Epic", "Initiative", "Page". Defaults to "Page".',
-                default: "Page",
-              },
-            },
-            required: ["query"],
-          },
-        },
-        {
-          name: "list_products",
-          description:
-            "List Aha! workspaces/products with id, reference prefix, and name",
-          inputSchema: {
-            type: "object",
-            properties: {},
-          },
-        },
-        {
-          name: "list_releases",
-          description:
-            "List releases in an Aha! product/workspace with id, reference number, name, and release date",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-            },
-            required: ["product_id"],
-          },
-        },
-        {
-          name: "get_release",
-          description:
-            "Get a specific Aha! release by its reference number (e.g. STU-R-46). Returns the release name, date, linked initiatives, and internal ID. Use this to confirm release details or get the ID needed for listing its contents.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              release_reference_num: {
-                type: "string",
-                description: "The release reference number, e.g. STU-R-46",
-              },
-            },
-            required: ["release_reference_num"],
-          },
-        },
-        {
-          name: "list_features_in_release",
-          description:
-            "List all features assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each feature's reference number, name, workflow status, assigned epic, and assignee. Features with a null epic field are not yet tied to an epic — useful for spotting coverage gaps.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              release_reference_num: {
-                type: "string",
-                description: "The release reference number, e.g. STU-R-46",
-              },
-            },
-            required: ["release_reference_num"],
-          },
-        },
-        {
-          name: "list_epics_in_release",
-          description:
-            "List all epics assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each epic's reference number, name, workflow status, and feature count.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              release_reference_num: {
-                type: "string",
-                description: "The release reference number, e.g. STU-R-46",
-              },
-            },
-            required: ["release_reference_num"],
-          },
-        },
-        {
-          name: "list_epics",
-          description:
-            "List Aha! epics in a product/workspace, returning reference numbers and names",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-            },
-            required: ["product_id"],
-          },
-        },
-        {
-          name: "list_features",
-          description:
-            "List Aha! features in a product/workspace, returning reference numbers and names",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-            },
-            required: ["product_id"],
-          },
-        },
-        {
-          name: "create_epic",
-          description:
-            "Create an Aha! epic in a product/workspace, optionally with HTML description",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-              name: {
-                type: "string",
-                description: "Epic name",
-              },
-              release_id: {
-                type: "string",
-                description: "Target release identifier",
-              },
-              description: {
-                type: "string",
-                description:
-                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
-              },
-            },
-            required: ["product_id", "name", "release_id"],
-          },
-        },
-        {
-          name: "create_feature",
-          description:
-            "Create an Aha! feature in a product/workspace, optionally linked to an epic and with HTML description",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-              name: {
-                type: "string",
-                description: "Feature name",
-              },
-              release_id: {
-                type: "string",
-                description: "Target release identifier",
-              },
-              epic_id: {
-                type: "string",
-                description: "Optional epic identifier to associate",
-              },
-              description: {
-                type: "string",
-                description:
-                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
-              },
-            },
-            required: ["product_id", "name", "release_id"],
-          },
-        },
-        {
-          name: "update_epic",
-          description:
-            "Update an Aha! epic by reference number; can update name, description, and/or linked release or initiative. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_epic` to retrieve the current epic state before updating.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Epic reference number",
-              },
-              name: {
-                type: "string",
-                description: "New epic name",
-              },
-              description: {
-                type: "string",
-                description:
-                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
-              },
-              initiative_reference_num: {
-                type: "string",
-                description:
-                  "Initiative reference number or ID to link this epic to (e.g., ACME-I-5)",
-              },
-              goal_ids: {
-                type: "array",
-                items: { type: "number" },
-                description:
-                  "Array of numeric goal IDs to link this epic to. Use list_goals to find IDs.",
-              },
-              workflow_status: {
-                type: "string",
-                description:
-                  "Workflow status name to set on this epic. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values.",
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "update_feature",
-          description:
-            "Update an Aha! feature by reference number; can update name, description, and/or linked release, epic, initiative, or assignee. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_record` to retrieve the current feature state before updating.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Feature reference number (e.g., DEVELOP-123)",
-              },
-              name: {
-                type: "string",
-                description: "New feature name",
-              },
-              description: {
-                type: "string",
-                description:
-                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
-              },
-              epic_id: {
-                type: "string",
-                description: "Epic reference number or ID to link this feature to",
-              },
-              initiative_reference_num: {
-                type: "string",
-                description:
-                  "Initiative reference number or ID to link this feature to (e.g., ACME-I-5)",
-              },
-              goal_ids: {
-                type: "array",
-                items: { type: "number" },
-                description:
-                  "Array of numeric goal IDs to link this feature to. Use list_goals to find IDs.",
-              },
-              workflow_status: {
-                type: "string",
-                description:
-                  "Workflow status name to set on this feature. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values.",
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "update_initiative",
-          description:
-            "Update an Aha! initiative by reference number; can update name, description, and/or link to goals",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Initiative reference number (e.g., ACME-I-5)",
-              },
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier that owns the initiative",
-              },
-              name: {
-                type: "string",
-                description: "New initiative name",
-              },
-              description: {
-                type: "string",
-                description:
-                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
-              },
-              goal_ids: {
-                type: "array",
-                items: { type: "number" },
-                description:
-                  "Array of numeric goal IDs to link this initiative to. Use list_goals to find IDs.",
-              },
-            },
-            required: ["reference_num", "product_id"],
-          },
-        },
-        {
-          name: "get_epic",
-          description: "Get an Aha! epic by reference number",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Epic reference number",
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "get_initiative",
-          description: "Get an Aha! initiative by reference number",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Initiative reference number",
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "get_goal",
-          description: "Get an Aha! goal by reference number",
-          inputSchema: {
-            type: "object",
-            properties: {
-              reference_num: {
-                type: "string",
-                description: "Goal reference number",
-              },
-            },
-            required: ["reference_num"],
-          },
-        },
-        {
-          name: "list_initiatives",
-          description:
-            "List Aha! initiatives in a product/workspace, returning IDs, reference numbers, and names",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-            },
-            required: ["product_id"],
-          },
-        },
-        {
-          name: "list_goals",
-          description:
-            "List Aha! goals in a product/workspace, returning IDs, reference numbers, and names",
-          inputSchema: {
-            type: "object",
-            properties: {
-              product_id: {
-                type: "string",
-                description: "Product/workspace identifier",
-              },
-            },
-            required: ["product_id"],
-          },
-        },
-        {
-          name: "list_workflow_statuses",
-          description:
-            "List all valid workflow status names for a given Aha! workspace. Returns status name, ID, position, and completion flag for each status in the workflow, grouped by workflow name. Call this before using update_feature or update_epic with a workflow_status value — status names are workspace-specific and cannot be assumed. Pass the workspace key (e.g. \"STU\") derived from any feature or epic reference number in that workspace.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              workspace_id: {
-                type: "string",
-                description:
-                  "Workspace key or numeric ID (e.g. \"LUM\" or \"LUM-1\"). Derived from the prefix of any feature or epic reference number in that workspace.",
-              },
-              record_type: {
-                type: "string",
-                enum: ["feature", "epic"],
-                description:
-                  "Type of record to retrieve statuses for: \"feature\" or \"epic\"",
-              },
-            },
-            required: ["workspace_id", "record_type"],
-          },
-        },
-      ],
-    }));
+      },
+      (args) => this.handlers.handleGetRecord({ params: { arguments: args } })
+    );
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      if (request.params.name === "get_record") {
-        return this.handlers.handleGetRecord(request);
-      } else if (request.params.name === "get_page") {
-        return this.handlers.handleGetPage(request);
-      } else if (request.params.name === "search_documents") {
-        return this.handlers.handleSearchDocuments(request);
-      } else if (request.params.name === "list_products") {
-        return this.handlers.handleListProducts();
-      } else if (request.params.name === "list_releases") {
-        return this.handlers.handleListReleases(request);
-      } else if (request.params.name === "get_release") {
-        return this.handlers.handleGetRelease(request);
-      } else if (request.params.name === "list_features_in_release") {
-        return this.handlers.handleListFeaturesInRelease(request);
-      } else if (request.params.name === "list_epics_in_release") {
-        return this.handlers.handleListEpicsInRelease(request);
-      } else if (request.params.name === "list_features") {
-        return this.handlers.handleListFeatures(request);
-      } else if (request.params.name === "list_epics") {
-        return this.handlers.handleListEpics(request);
-      } else if (request.params.name === "create_epic") {
-        return this.handlers.handleCreateEpic(request);
-      } else if (request.params.name === "create_feature") {
-        return this.handlers.handleCreateFeature(request);
-      } else if (request.params.name === "update_epic") {
-        return this.handlers.handleUpdateEpic(request);
-      } else if (request.params.name === "update_feature") {
-        return this.handlers.handleUpdateFeature(request);
-      } else if (request.params.name === "update_initiative") {
-        return this.handlers.handleUpdateInitiative(request);
-      } else if (request.params.name === "get_epic") {
-        return this.handlers.handleGetEpic(request);
-      } else if (request.params.name === "get_initiative") {
-        return this.handlers.handleGetInitiative(request);
-      } else if (request.params.name === "get_goal") {
-        return this.handlers.handleGetGoal(request);
-      } else if (request.params.name === "list_initiatives") {
-        return this.handlers.handleListInitiatives(request);
-      } else if (request.params.name === "list_goals") {
-        return this.handlers.handleListGoals(request);
-      } else if (request.params.name === "list_workflow_statuses") {
-        return this.handlers.handleListWorkflowStatuses(request);
-      }
+    this.server.registerTool(
+      "get_page",
+      {
+        description:
+          "Get an Aha! page by reference number with optional relationships",
+        inputSchema: {
+          reference_num: z
+            .string()
+            .describe("Reference number (e.g., ABC-N-213)"),
+          includeParent: z
+            .boolean()
+            .optional()
+            .describe("Include parent page in the response"),
+        },
+      },
+      (args) => this.handlers.handleGetPage({ params: { arguments: args } })
+    );
 
-      throw new McpError(
-        ErrorCode.MethodNotFound,
-        `Unknown tool: ${request.params.name}`
-      );
-    });
+    this.server.registerTool(
+      "search_documents",
+      {
+        description:
+          "Search Aha! records by full-text query across features, epics, initiatives, or pages",
+        inputSchema: {
+          query: z.string().describe("Search query string"),
+          searchableType: z
+            .string()
+            .optional()
+            .describe(
+              'Type of record to search. Valid values: "Feature", "Epic", "Initiative", "Page". Defaults to "Page".'
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleSearchDocuments({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_products",
+      {
+        description:
+          "List Aha! workspaces/products with id, reference prefix, and name",
+      },
+      () => this.handlers.handleListProducts()
+    );
+
+    this.server.registerTool(
+      "list_releases",
+      {
+        description:
+          "List releases in an Aha! product/workspace with id, reference number, name, and release date",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListReleases({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "get_release",
+      {
+        description:
+          "Get a specific Aha! release by its reference number (e.g. STU-R-46). Returns the release name, date, linked initiatives, and internal ID. Use this to confirm release details or get the ID needed for listing its contents.",
+        inputSchema: {
+          release_reference_num: z
+            .string()
+            .describe("The release reference number, e.g. STU-R-46"),
+        },
+      },
+      (args) =>
+        this.handlers.handleGetRelease({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_features_in_release",
+      {
+        description:
+          "List all features assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each feature's reference number, name, workflow status, assigned epic, and assignee. Features with a null epic field are not yet tied to an epic — useful for spotting coverage gaps.",
+        inputSchema: {
+          release_reference_num: z
+            .string()
+            .describe("The release reference number, e.g. STU-R-46"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListFeaturesInRelease({
+          params: { arguments: args },
+        })
+    );
+
+    this.server.registerTool(
+      "list_epics_in_release",
+      {
+        description:
+          "List all epics assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each epic's reference number, name, workflow status, and feature count.",
+        inputSchema: {
+          release_reference_num: z
+            .string()
+            .describe("The release reference number, e.g. STU-R-46"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListEpicsInRelease({
+          params: { arguments: args },
+        })
+    );
+
+    this.server.registerTool(
+      "list_epics",
+      {
+        description:
+          "List Aha! epics in a product/workspace, returning reference numbers and names",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListEpics({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_features",
+      {
+        description:
+          "List Aha! features in a product/workspace, returning reference numbers and names",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListFeatures({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "create_epic",
+      {
+        description:
+          "Create an Aha! epic in a product/workspace, optionally with HTML description",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+          name: z.string().describe("Epic name"),
+          release_id: z.string().describe("Target release identifier"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleCreateEpic({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "create_feature",
+      {
+        description:
+          "Create an Aha! feature in a product/workspace, optionally linked to an epic and with HTML description",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+          name: z.string().describe("Feature name"),
+          release_id: z.string().describe("Target release identifier"),
+          epic_id: z
+            .string()
+            .optional()
+            .describe("Optional epic identifier to associate"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleCreateFeature({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "update_epic",
+      {
+        description:
+          "Update an Aha! epic by reference number; can update name, description, and/or linked release or initiative. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_epic` to retrieve the current epic state before updating.",
+        inputSchema: {
+          reference_num: z.string().describe("Epic reference number"),
+          name: z.string().optional().describe("New epic name"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+          initiative_reference_num: z
+            .string()
+            .optional()
+            .describe(
+              "Initiative reference number or ID to link this epic to (e.g., ACME-I-5)"
+            ),
+          goal_ids: z
+            .array(z.number())
+            .optional()
+            .describe(
+              "Array of numeric goal IDs to link this epic to. Use list_goals to find IDs."
+            ),
+          workflow_status: z
+            .string()
+            .optional()
+            .describe(
+              "Workflow status name to set on this epic. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleUpdateEpic({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "update_feature",
+      {
+        description:
+          "Update an Aha! feature by reference number; can update name, description, and/or linked release, epic, initiative, or assignee. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_record` to retrieve the current feature state before updating.",
+        inputSchema: {
+          reference_num: z
+            .string()
+            .describe("Feature reference number (e.g., DEVELOP-123)"),
+          name: z.string().optional().describe("New feature name"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+          epic_id: z
+            .string()
+            .optional()
+            .describe("Epic reference number or ID to link this feature to"),
+          initiative_reference_num: z
+            .string()
+            .optional()
+            .describe(
+              "Initiative reference number or ID to link this feature to (e.g., ACME-I-5)"
+            ),
+          goal_ids: z
+            .array(z.number())
+            .optional()
+            .describe(
+              "Array of numeric goal IDs to link this feature to. Use list_goals to find IDs."
+            ),
+          workflow_status: z
+            .string()
+            .optional()
+            .describe(
+              "Workflow status name to set on this feature. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleUpdateFeature({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "update_initiative",
+      {
+        description:
+          "Update an Aha! initiative by reference number; can update name, description, and/or link to goals",
+        inputSchema: {
+          reference_num: z
+            .string()
+            .describe("Initiative reference number (e.g., ACME-I-5)"),
+          product_id: z
+            .string()
+            .describe(
+              "Product/workspace identifier that owns the initiative"
+            ),
+          name: z.string().optional().describe("New initiative name"),
+          description: z
+            .string()
+            .optional()
+            .describe(
+              "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
+            ),
+          goal_ids: z
+            .array(z.number())
+            .optional()
+            .describe(
+              "Array of numeric goal IDs to link this initiative to. Use list_goals to find IDs."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleUpdateInitiative({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "get_epic",
+      {
+        description: "Get an Aha! epic by reference number",
+        inputSchema: {
+          reference_num: z.string().describe("Epic reference number"),
+        },
+      },
+      (args) =>
+        this.handlers.handleGetEpic({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "get_initiative",
+      {
+        description: "Get an Aha! initiative by reference number",
+        inputSchema: {
+          reference_num: z.string().describe("Initiative reference number"),
+        },
+      },
+      (args) =>
+        this.handlers.handleGetInitiative({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "get_goal",
+      {
+        description: "Get an Aha! goal by reference number",
+        inputSchema: {
+          reference_num: z.string().describe("Goal reference number"),
+        },
+      },
+      (args) =>
+        this.handlers.handleGetGoal({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_initiatives",
+      {
+        description:
+          "List Aha! initiatives in a product/workspace, returning IDs, reference numbers, and names",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListInitiatives({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_goals",
+      {
+        description:
+          "List Aha! goals in a product/workspace, returning IDs, reference numbers, and names",
+        inputSchema: {
+          product_id: z.string().describe("Product/workspace identifier"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListGoals({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_workflow_statuses",
+      {
+        description:
+          'List all valid workflow status names for a given Aha! workspace. Returns status name, ID, position, and completion flag for each status in the workflow, grouped by workflow name. Call this before using update_feature or update_epic with a workflow_status value — status names are workspace-specific and cannot be assumed. Pass the workspace key (e.g. "STU") derived from any feature or epic reference number in that workspace.',
+        inputSchema: {
+          workspace_id: z
+            .string()
+            .describe(
+              'Workspace key or numeric ID (e.g. "LUM" or "LUM-1"). Derived from the prefix of any feature or epic reference number in that workspace.'
+            ),
+          record_type: z
+            .enum(["feature", "epic"])
+            .describe(
+              'Type of record to retrieve statuses for: "feature" or "epic"'
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleListWorkflowStatuses({
+          params: { arguments: args },
+        })
+    );
   }
 
   async run() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,7 @@ class AhaMcp {
           record_type: z
             .string()
             .describe(
-              "Type of the record to list links for. One of: feature, epic, release, idea, initiative, page, goal, release_phase, requirement"
+              "Type of the record to list links for. Currently only \"feature\" is supported by the Aha! record-links listing endpoint."
             ),
           reference_num: z
             .string()

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ class AhaMcp {
       },
       {
         capabilities: {
-          tools: {},
+          tools: { listChanged: true },
         },
       }
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,8 @@ class AhaMcp {
         },
         {
           name: "search_documents",
-          description: "Search for Aha! documents",
+          description:
+            "Search Aha! records by full-text query across features, epics, initiatives, or pages",
           inputSchema: {
             type: "object",
             properties: {
@@ -114,7 +115,8 @@ class AhaMcp {
               },
               searchableType: {
                 type: "string",
-                description: "Type of document to search for (e.g., Page)",
+                description:
+                  'Type of record to search. Valid values: "Feature", "Epic", "Initiative", "Page". Defaults to "Page".',
                 default: "Page",
               },
             },
@@ -238,7 +240,7 @@ class AhaMcp {
         {
           name: "update_epic",
           description:
-            "Update an Aha! epic by reference number; can update name and/or description",
+            "Update an Aha! epic by reference number; can update name, description, and/or linking fields (initiative, goals)",
           inputSchema: {
             type: "object",
             properties: {
@@ -255,6 +257,17 @@ class AhaMcp {
                 description:
                   "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
               },
+              initiative_reference_num: {
+                type: "string",
+                description:
+                  "Initiative reference number or ID to link this epic to (e.g., ACME-I-5)",
+              },
+              goal_ids: {
+                type: "array",
+                items: { type: "number" },
+                description:
+                  "Array of numeric goal IDs to link this epic to. Use list_goals to find IDs.",
+              },
             },
             required: ["reference_num"],
           },
@@ -262,7 +275,7 @@ class AhaMcp {
         {
           name: "update_feature",
           description:
-            "Update an Aha! feature by reference number; can update name and/or description",
+            "Update an Aha! feature by reference number; can update name, description, and/or linking fields (epic, initiative, goals)",
           inputSchema: {
             type: "object",
             properties: {
@@ -278,6 +291,51 @@ class AhaMcp {
                 type: "string",
                 description:
                   "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
+              },
+              epic_id: {
+                type: "string",
+                description: "Epic reference number or ID to link this feature to",
+              },
+              initiative_reference_num: {
+                type: "string",
+                description:
+                  "Initiative reference number or ID to link this feature to (e.g., ACME-I-5)",
+              },
+              goal_ids: {
+                type: "array",
+                items: { type: "number" },
+                description:
+                  "Array of numeric goal IDs to link this feature to. Use list_goals to find IDs.",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "update_initiative",
+          description:
+            "Update an Aha! initiative by reference number; can update name, description, and/or link to goals",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Initiative reference number (e.g., ACME-I-5)",
+              },
+              name: {
+                type: "string",
+                description: "New initiative name",
+              },
+              description: {
+                type: "string",
+                description:
+                  "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content.",
+              },
+              goal_ids: {
+                type: "array",
+                items: { type: "number" },
+                description:
+                  "Array of numeric goal IDs to link this initiative to. Use list_goals to find IDs.",
               },
             },
             required: ["reference_num"],
@@ -328,7 +386,7 @@ class AhaMcp {
         {
           name: "list_initiatives",
           description:
-            "List Aha! initiatives in a product/workspace, returning reference numbers and names",
+            "List Aha! initiatives in a product/workspace, returning IDs, reference numbers, and names",
           inputSchema: {
             type: "object",
             properties: {
@@ -343,7 +401,7 @@ class AhaMcp {
         {
           name: "list_goals",
           description:
-            "List Aha! goals in a product/workspace, returning reference numbers and names",
+            "List Aha! goals in a product/workspace, returning IDs, reference numbers, and names",
           inputSchema: {
             type: "object",
             properties: {
@@ -381,6 +439,8 @@ class AhaMcp {
         return this.handlers.handleUpdateEpic(request);
       } else if (request.params.name === "update_feature") {
         return this.handlers.handleUpdateFeature(request);
+      } else if (request.params.name === "update_initiative") {
+        return this.handlers.handleUpdateInitiative(request);
       } else if (request.params.name === "get_epic") {
         return this.handlers.handleGetEpic(request);
       } else if (request.params.name === "get_initiative") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,78 @@ class AhaMcp {
             required: ["reference_num"],
           },
         },
+        {
+          name: "get_epic",
+          description: "Get an Aha! epic by reference number",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Epic reference number",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "get_initiative",
+          description: "Get an Aha! initiative by reference number",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Initiative reference number",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "get_goal",
+          description: "Get an Aha! goal by reference number",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Goal reference number",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "list_initiatives",
+          description:
+            "List Aha! initiatives in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_goals",
+          description:
+            "List Aha! goals in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
       ],
     }));
 
@@ -309,6 +381,16 @@ class AhaMcp {
         return this.handlers.handleUpdateEpic(request);
       } else if (request.params.name === "update_feature") {
         return this.handlers.handleUpdateFeature(request);
+      } else if (request.params.name === "get_epic") {
+        return this.handlers.handleGetEpic(request);
+      } else if (request.params.name === "get_initiative") {
+        return this.handlers.handleGetInitiative(request);
+      } else if (request.params.name === "get_goal") {
+        return this.handlers.handleGetGoal(request);
+      } else if (request.params.name === "list_initiatives") {
+        return this.handlers.handleListInitiatives(request);
+      } else if (request.params.name === "list_goals") {
+        return this.handlers.handleListGoals(request);
       }
 
       throw new McpError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,14 @@ if (!AHA_DOMAIN) {
   throw new Error("AHA_DOMAIN environment variable is required");
 }
 
+const verifiedAhaApiToken = AHA_API_TOKEN;
+const verifiedAhaDomain = AHA_DOMAIN;
+
 const client = new GraphQLClient(
-  `https://${AHA_DOMAIN}.aha.io/api/v2/graphql`,
+  `https://${verifiedAhaDomain}.aha.io/api/v2/graphql`,
   {
     headers: {
-      Authorization: `Bearer ${AHA_API_TOKEN}`,
+      Authorization: `Bearer ${verifiedAhaApiToken}`,
     },
   }
 );
@@ -47,7 +50,11 @@ class AhaMcp {
       }
     );
 
-    this.handlers = new Handlers(client);
+    this.handlers = new Handlers(
+      client,
+      verifiedAhaDomain,
+      verifiedAhaApiToken
+    );
     this.setupToolHandlers();
 
     this.server.onerror = (error) => console.error("[MCP Error]", error);
@@ -114,6 +121,160 @@ class AhaMcp {
             required: ["query"],
           },
         },
+        {
+          name: "list_products",
+          description:
+            "List Aha! workspaces/products with id, reference prefix, and name",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+        {
+          name: "list_releases",
+          description:
+            "List releases in an Aha! product/workspace with id, name, and release date",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_epics",
+          description:
+            "List Aha! epics in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "list_features",
+          description:
+            "List Aha! features in a product/workspace, returning reference numbers and names",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+            },
+            required: ["product_id"],
+          },
+        },
+        {
+          name: "create_epic",
+          description:
+            "Create an Aha! epic in a product/workspace, optionally with HTML description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier",
+              },
+              name: {
+                type: "string",
+                description: "Epic name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              description: {
+                type: "string",
+                description: "Optional description text",
+              },
+            },
+            required: ["product_id", "name", "release_id"],
+          },
+        },
+        {
+          name: "create_feature",
+          description:
+            "Create an Aha! feature in a release, optionally linked to an epic",
+          inputSchema: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                description: "Feature name",
+              },
+              release_id: {
+                type: "string",
+                description: "Target release identifier",
+              },
+              epic_id: {
+                type: "string",
+                description: "Optional epic identifier to associate",
+              },
+              description: {
+                type: "string",
+                description: "Optional description text",
+              },
+            },
+            required: ["name", "release_id"],
+          },
+        },
+        {
+          name: "update_epic",
+          description:
+            "Update an Aha! epic by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Epic reference number",
+              },
+              name: {
+                type: "string",
+                description: "New epic name",
+              },
+              description: {
+                type: "string",
+                description: "New description text",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
+        {
+          name: "update_feature",
+          description:
+            "Update an Aha! feature by reference number; can update name and/or description",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference_num: {
+                type: "string",
+                description: "Feature reference number (e.g., DEVELOP-123)",
+              },
+              name: {
+                type: "string",
+                description: "New feature name",
+              },
+              description: {
+                type: "string",
+                description: "New description text",
+              },
+            },
+            required: ["reference_num"],
+          },
+        },
       ],
     }));
 
@@ -124,6 +285,22 @@ class AhaMcp {
         return this.handlers.handleGetPage(request);
       } else if (request.params.name === "search_documents") {
         return this.handlers.handleSearchDocuments(request);
+      } else if (request.params.name === "list_products") {
+        return this.handlers.handleListProducts();
+      } else if (request.params.name === "list_releases") {
+        return this.handlers.handleListReleases(request);
+      } else if (request.params.name === "list_features") {
+        return this.handlers.handleListFeatures(request);
+      } else if (request.params.name === "list_epics") {
+        return this.handlers.handleListEpics(request);
+      } else if (request.params.name === "create_epic") {
+        return this.handlers.handleCreateEpic(request);
+      } else if (request.params.name === "create_feature") {
+        return this.handlers.handleCreateFeature(request);
+      } else if (request.params.name === "update_epic") {
+        return this.handlers.handleUpdateEpic(request);
+      } else if (request.params.name === "update_feature") {
+        return this.handlers.handleUpdateFeature(request);
       }
 
       throw new McpError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,10 +275,10 @@ class AhaMcp {
               "Initiative reference number or ID to link this epic to (e.g., ACME-I-5)"
             ),
           goal_ids: z
-            .array(z.number())
+            .array(z.string())
             .optional()
             .describe(
-              "Array of numeric goal IDs to link this epic to. Use list_goals to find IDs."
+              "Array of goal IDs to link this epic to. Use list_goals to find IDs. Pass as strings to preserve full 64-bit precision, e.g. [\"7374514016881184006\"]."
             ),
           workflow_status: z
             .string()
@@ -319,10 +319,10 @@ class AhaMcp {
               "Initiative reference number or ID to link this feature to (e.g., ACME-I-5)"
             ),
           goal_ids: z
-            .array(z.number())
+            .array(z.string())
             .optional()
             .describe(
-              "Array of numeric goal IDs to link this feature to. Use list_goals to find IDs."
+              "Array of goal IDs to link this feature to. Use list_goals to find IDs. Pass as strings to preserve full 64-bit precision, e.g. [\"7374514016881184006\"]."
             ),
           workflow_status: z
             .string()
@@ -358,10 +358,10 @@ class AhaMcp {
               "Record body as raw HTML. Aha stores and renders HTML directly — pass well-formed tags (e.g. <p>Text here</p>, <ul><li>Item</li></ul>). Do not pass markdown. Do not HTML-entity-encode structural tags — only encode literal <, >, or & characters that appear as text content."
             ),
           goal_ids: z
-            .array(z.number())
+            .array(z.string())
             .optional()
             .describe(
-              "Array of numeric goal IDs to link this initiative to. Use list_goals to find IDs."
+              "Array of goal IDs to link this initiative to. Use list_goals to find IDs. Pass as strings to preserve full 64-bit precision, e.g. [\"7374514016881184006\"]."
             ),
         },
       },
@@ -429,6 +429,79 @@ class AhaMcp {
       },
       (args) =>
         this.handlers.handleListGoals({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "create_record_link",
+      {
+        description:
+          "Create a relationship between any two Aha! records using reference numbers (e.g. STU-88, AP-E-79). Automatically routes ownership relationships (feature/epic to goal, initiative, release, or parent epic) to the correct field setter — no need to call update_feature or update_epic separately. For peer relationships use link_type: 10=Relates to, 20=Depends on, 30=Duplicated by, 40=Contained by, 50=Impacted by, 60=Blocked by, 80=Research for. link_type is optional — omit it and the handler infers from the record type hierarchy or asks. Supported types: feature, epic, release, idea, initiative, page, goal, release_phase, requirement.",
+        inputSchema: {
+          source_record_type: z
+            .string()
+            .describe(
+              "Type of the source record. One of: feature, epic, release, idea, initiative, page, goal, release_phase, requirement"
+            ),
+          source_reference_num: z
+            .string()
+            .describe(
+              "Reference number of the source record (e.g. STU-88, AP-E-79)"
+            ),
+          target_record_type: z
+            .string()
+            .describe(
+              "Type of the record being linked to. Same allowed values as source_record_type"
+            ),
+          target_reference_num: z
+            .string()
+            .describe("Reference number of the target record"),
+          link_type: z
+            .number()
+            .optional()
+            .describe(
+              "Numeric link type code: 10=Relates to, 20=Depends on, 30=Duplicated by, 40=Contained by, 50=Impacted by, 60=Blocked by, 80=Research for. Omit to let the handler infer from the record type hierarchy. Not used for ownership-routed cases (goal, initiative, release, epic parent)."
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleCreateRecordLink({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "list_record_links",
+      {
+        description:
+          "List all linked records for a given Aha! record. Returns each link's internal ID, relationship label, linked record reference number, name, and status. Use this before delete_record_link to obtain the link_id, or to inspect existing relationships before creating new ones.",
+        inputSchema: {
+          record_type: z
+            .string()
+            .describe(
+              "Type of the record to list links for. One of: feature, epic, release, idea, initiative, page, goal, release_phase, requirement"
+            ),
+          reference_num: z
+            .string()
+            .describe("Reference number of the record (e.g. STU-88, AP-E-79)"),
+        },
+      },
+      (args) =>
+        this.handlers.handleListRecordLinks({ params: { arguments: args } })
+    );
+
+    this.server.registerTool(
+      "delete_record_link",
+      {
+        description:
+          "Delete a specific record link by its internal link ID. Use list_record_links first to find the link_id. Works for all relationship types including \"Belongs to initiative\" and \"Belongs to goal\" ownership links. Always confirm with the user before deleting ownership links, as removing them affects roadmap rollups and reporting.",
+        inputSchema: {
+          link_id: z
+            .string()
+            .describe(
+              "Internal ID of the link to delete, as returned by list_record_links"
+            ),
+        },
+      },
+      (args) =>
+        this.handlers.handleDeleteRecordLink({ params: { arguments: args } })
     );
 
     this.server.registerTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ class AhaMcp {
       tools: [
         {
           name: "get_record",
-          description: "Get an Aha! feature or requirement by reference number",
+          description: "Get an Aha! feature or requirement by reference number. Returns name, description, workflow status (name, complete flag), and linked epic. Use this to read current feature state before updating, or to confirm status after a update_feature call. For epics, use get_epic instead.",
           inputSchema: {
             type: "object",
             properties: {
@@ -135,7 +135,7 @@ class AhaMcp {
         {
           name: "list_releases",
           description:
-            "List releases in an Aha! product/workspace with id, name, and release date",
+            "List releases in an Aha! product/workspace with id, reference number, name, and release date",
           inputSchema: {
             type: "object",
             properties: {
@@ -145,6 +145,51 @@ class AhaMcp {
               },
             },
             required: ["product_id"],
+          },
+        },
+        {
+          name: "get_release",
+          description:
+            "Get a specific Aha! release by its reference number (e.g. STU-R-46). Returns the release name, date, linked initiatives, and internal ID. Use this to confirm release details or get the ID needed for listing its contents.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              release_reference_num: {
+                type: "string",
+                description: "The release reference number, e.g. STU-R-46",
+              },
+            },
+            required: ["release_reference_num"],
+          },
+        },
+        {
+          name: "list_features_in_release",
+          description:
+            "List all features assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each feature's reference number, name, workflow status, assigned epic, and assignee. Features with a null epic field are not yet tied to an epic — useful for spotting coverage gaps.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              release_reference_num: {
+                type: "string",
+                description: "The release reference number, e.g. STU-R-46",
+              },
+            },
+            required: ["release_reference_num"],
+          },
+        },
+        {
+          name: "list_epics_in_release",
+          description:
+            "List all epics assigned to a specific Aha! release, identified by reference number (e.g. STU-R-46). Returns each epic's reference number, name, workflow status, and feature count.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              release_reference_num: {
+                type: "string",
+                description: "The release reference number, e.g. STU-R-46",
+              },
+            },
+            required: ["release_reference_num"],
           },
         },
         {
@@ -240,7 +285,7 @@ class AhaMcp {
         {
           name: "update_epic",
           description:
-            "Update an Aha! epic by reference number; can update name, description, and/or linking fields (initiative, goals)",
+            "Update an Aha! epic by reference number; can update name, description, and/or linked release or initiative. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_epic` to retrieve the current epic state before updating.",
           inputSchema: {
             type: "object",
             properties: {
@@ -268,6 +313,11 @@ class AhaMcp {
                 description:
                   "Array of numeric goal IDs to link this epic to. Use list_goals to find IDs.",
               },
+              workflow_status: {
+                type: "string",
+                description:
+                  "Workflow status name to set on this epic. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values.",
+              },
             },
             required: ["reference_num"],
           },
@@ -275,7 +325,7 @@ class AhaMcp {
         {
           name: "update_feature",
           description:
-            "Update an Aha! feature by reference number; can update name, description, and/or linking fields (epic, initiative, goals)",
+            "Update an Aha! feature by reference number; can update name, description, and/or linked release, epic, initiative, or assignee. Also supports setting `workflow_status` by name — status names are workspace-specific, so call `list_workflow_statuses` first if you are unsure of the valid values. Use `get_record` to retrieve the current feature state before updating.",
           inputSchema: {
             type: "object",
             properties: {
@@ -306,6 +356,11 @@ class AhaMcp {
                 items: { type: "number" },
                 description:
                   "Array of numeric goal IDs to link this feature to. Use list_goals to find IDs.",
+              },
+              workflow_status: {
+                type: "string",
+                description:
+                  "Workflow status name to set on this feature. Status names are workspace-specific — call list_workflow_statuses to retrieve valid values.",
               },
             },
             required: ["reference_num"],
@@ -417,6 +472,28 @@ class AhaMcp {
             required: ["product_id"],
           },
         },
+        {
+          name: "list_workflow_statuses",
+          description:
+            "List all valid workflow status names for a given Aha! workspace. Returns status name, ID, position, and completion flag for each status in the workflow, grouped by workflow name. Call this before using update_feature or update_epic with a workflow_status value — status names are workspace-specific and cannot be assumed. Pass the workspace key (e.g. \"STU\") derived from any feature or epic reference number in that workspace.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspace_id: {
+                type: "string",
+                description:
+                  "Workspace key or numeric ID (e.g. \"LUM\" or \"LUM-1\"). Derived from the prefix of any feature or epic reference number in that workspace.",
+              },
+              record_type: {
+                type: "string",
+                enum: ["feature", "epic"],
+                description:
+                  "Type of record to retrieve statuses for: \"feature\" or \"epic\"",
+              },
+            },
+            required: ["workspace_id", "record_type"],
+          },
+        },
       ],
     }));
 
@@ -431,6 +508,12 @@ class AhaMcp {
         return this.handlers.handleListProducts();
       } else if (request.params.name === "list_releases") {
         return this.handlers.handleListReleases(request);
+      } else if (request.params.name === "get_release") {
+        return this.handlers.handleGetRelease(request);
+      } else if (request.params.name === "list_features_in_release") {
+        return this.handlers.handleListFeaturesInRelease(request);
+      } else if (request.params.name === "list_epics_in_release") {
+        return this.handlers.handleListEpicsInRelease(request);
       } else if (request.params.name === "list_features") {
         return this.handlers.handleListFeatures(request);
       } else if (request.params.name === "list_epics") {
@@ -455,6 +538,8 @@ class AhaMcp {
         return this.handlers.handleListInitiatives(request);
       } else if (request.params.name === "list_goals") {
         return this.handlers.handleListGoals(request);
+      } else if (request.params.name === "list_workflow_statuses") {
+        return this.handlers.handleListWorkflowStatuses(request);
       }
 
       throw new McpError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,13 +73,13 @@ class AhaMcp {
           inputSchema: {
             type: "object",
             properties: {
-              reference: {
+              reference_num: {
                 type: "string",
                 description:
                   "Reference number (e.g., DEVELOP-123 or ADT-123-1)",
               },
             },
-            required: ["reference"],
+            required: ["reference_num"],
           },
         },
         {
@@ -89,7 +89,7 @@ class AhaMcp {
           inputSchema: {
             type: "object",
             properties: {
-              reference: {
+              reference_num: {
                 type: "string",
                 description: "Reference number (e.g., ABC-N-213)",
               },
@@ -99,7 +99,7 @@ class AhaMcp {
                 default: false,
               },
             },
-            required: ["reference"],
+            required: ["reference_num"],
           },
         },
         {
@@ -322,6 +322,10 @@ class AhaMcp {
                 type: "string",
                 description: "Initiative reference number (e.g., ACME-I-5)",
               },
+              product_id: {
+                type: "string",
+                description: "Product/workspace identifier that owns the initiative",
+              },
               name: {
                 type: "string",
                 description: "New initiative name",
@@ -338,7 +342,7 @@ class AhaMcp {
                   "Array of numeric goal IDs to link this initiative to. Use list_goals to find IDs.",
               },
             },
-            required: ["reference_num"],
+            required: ["reference_num", "product_id"],
           },
         },
         {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -17,28 +17,6 @@ export const getPageQuery = `
   }
 `;
 
-export const getFeatureQuery = `
-  query GetFeature($id: ID!) {
-    feature(id: $id) {
-      name
-      description {
-        markdownBody
-      }
-    }
-  }
-`;
-
-export const getRequirementQuery = `
-  query GetRequirement($id: ID!) {
-    requirement(id: $id) {
-      name
-      description {
-        markdownBody
-      }
-    }
-  }
-`;
-
 export const searchDocumentsQuery = `
   query SearchDocuments($query: String!, $searchableType: [String!]!) {
     searchDocuments(filters: {query: $query, searchableType: $searchableType}) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,3 +89,23 @@ export interface AhaReleaseSummary {
 export interface ListReleasesResponse {
   releases: AhaReleaseSummary[];
 }
+
+export interface AhaGoalSummary {
+  id: string | number;
+  reference_num: string;
+  name: string;
+}
+
+export interface AhaInitiativeSummary {
+  id: string | number;
+  reference_num: string;
+  name: string;
+}
+
+export interface ListGoalsResponse {
+  goals: AhaGoalSummary[];
+}
+
+export interface ListInitiativesResponse {
+  initiatives: AhaInitiativeSummary[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,18 @@ export interface Description {
   htmlBody: string;
 }
 
+export interface AhaWorkflowStatus {
+  id: string;
+  name: string;
+  position: number;
+  complete: boolean;
+  color: string;
+}
+
 export interface Record {
   name: string;
   description: Description;
+  workflow_status?: AhaWorkflowStatus | null;
 }
 
 export interface FeatureResponse {
@@ -85,6 +94,7 @@ export interface ListProductsResponse {
 export interface AhaReleaseSummary {
   id: string | number;
   name: string;
+  reference_num: string;
   release_date: string | null;
 }
 
@@ -110,4 +120,23 @@ export interface ListGoalsResponse {
 
 export interface ListInitiativesResponse {
   initiatives: AhaInitiativeSummary[];
+}
+
+export interface AhaFeatureInReleaseSummary {
+  id: string | number;
+  reference_num: string;
+  name: string;
+  workflow_status: { name: string } | null;
+  epic: { id: string | number; reference_num: string; name: string } | null;
+  assigned_to_user: { name: string } | null;
+  url: string;
+}
+
+export interface AhaEpicInReleaseSummary {
+  id: string | number;
+  reference_num: string;
+  name: string;
+  workflow_status: { name: string } | null;
+  features_count: number;
+  url: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,11 +53,13 @@ export interface SearchResponse {
 }
 
 export interface AhaFeatureSummary {
+  id: string | number;
   reference_num: string;
   name: string;
 }
 
 export interface AhaEpicSummary {
+  id: string | number;
   reference_num: string;
   name: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,3 +140,26 @@ export interface AhaEpicInReleaseSummary {
   features_count: number;
   url: string;
 }
+
+export interface RecordLink {
+  link_id: string;
+  relationship: string;
+  linked_record_type: string;
+  linked_record_reference_num: string;
+  linked_record_name: string;
+  linked_record_status: string;
+}
+
+export interface CreateRecordLinkResult {
+  success: boolean;
+  mechanism: string;
+  source: string;
+  target: string;
+  relationship: string;
+  note?: string;
+}
+
+export interface DeleteRecordLinkResult {
+  success: boolean;
+  link_id: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,3 +163,9 @@ export interface DeleteRecordLinkResult {
   success: boolean;
   link_id: string;
 }
+
+export interface AhaCompetitorSummary {
+  id: string | number;
+  reference_num: string;
+  name: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,41 @@ export interface SearchResponse {
     isLastPage: boolean;
   };
 }
+
+export interface AhaFeatureSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface AhaEpicSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface ListFeaturesResponse {
+  features: AhaFeatureSummary[];
+}
+
+export interface ListEpicsResponse {
+  epics: AhaEpicSummary[];
+}
+
+export interface AhaProductSummary {
+  id: string | number;
+  reference_prefix: string;
+  name: string;
+}
+
+export interface ListProductsResponse {
+  products: AhaProductSummary[];
+}
+
+export interface AhaReleaseSummary {
+  id: string | number;
+  name: string;
+  release_date: string | null;
+}
+
+export interface ListReleasesResponse {
+  releases: AhaReleaseSummary[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,59 @@ export interface SearchResponse {
     isLastPage: boolean;
   };
 }
+
+export interface AhaFeatureSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface AhaEpicSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface ListFeaturesResponse {
+  features: AhaFeatureSummary[];
+}
+
+export interface ListEpicsResponse {
+  epics: AhaEpicSummary[];
+}
+
+export interface AhaProductSummary {
+  id: string | number;
+  reference_prefix: string;
+  name: string;
+}
+
+export interface ListProductsResponse {
+  products: AhaProductSummary[];
+}
+
+export interface AhaReleaseSummary {
+  id: string | number;
+  name: string;
+  release_date: string | null;
+}
+
+export interface ListReleasesResponse {
+  releases: AhaReleaseSummary[];
+}
+
+export interface AhaInitiativeSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface ListInitiativesResponse {
+  initiatives: AhaInitiativeSummary[];
+}
+
+export interface AhaGoalSummary {
+  reference_num: string;
+  name: string;
+}
+
+export interface ListGoalsResponse {
+  goals: AhaGoalSummary[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
The current aha-mcp toolset has no support for Competitor record type. `get_page` rejects the `C` prefix outright, and `search_documents` returns no results for competitor content. This gap means that the planned competitive research refresh workflow — which reads data from an Obsidian knowledge base and writes updated summaries back to Aha! — cannot be completed without manual copy-paste.

Adding four tools (`list_competitors`, `get_competitor`, `update_competitor`, `create_competitor`) will close this gap and make the full refresh workflow automatable.