### PR TITLE
feat: add epic support to get_record

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,15 +4,18 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
+  EPIC_REF_REGEX,
   Record,
   FeatureResponse,
   RequirementResponse,
+  EpicResponse,
   PageResponse,
   SearchResponse,
 } from "./types.js";
 import {
   getFeatureQuery,
   getRequirementQuery,
+  getEpicQuery,
   getPageQuery,
   searchDocumentsQuery,
 } from "./queries.js";
@@ -36,9 +39,7 @@ export class Handlers {
       if (FEATURE_REF_REGEX.test(reference)) {
         const data = await this.client.request<FeatureResponse>(
           getFeatureQuery,
-          {
-            id: reference,
-          }
+          { id: reference }
         );
         result = data.feature;
       } else if (REQUIREMENT_REF_REGEX.test(reference)) {
@@ -47,10 +48,16 @@ export class Handlers {
           { id: reference }
         );
         result = data.requirement;
+      } else if (EPIC_REF_REGEX.test(reference)) {
+        const data = await this.client.request<EpicResponse>(
+          getEpicQuery,
+          { id: reference }
+        );
+        result = data.epic;
       } else {
         throw new McpError(
           ErrorCode.InvalidParams,
-          "Invalid reference number format. Expected DEVELOP-123 or ADT-123-1"
+          "Invalid reference number format. Expected DEVELOP-123, ADT-123-1, or DCOMMS-E-157"
         );
       }
 
@@ -77,7 +84,6 @@ export class Handlers {
       if (error instanceof McpError) {
         throw error;
       }
-
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       console.error("API Error:", errorMessage);
@@ -137,7 +143,6 @@ export class Handlers {
       if (error instanceof McpError) {
         throw error;
       }
-
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       console.error("API Error:", errorMessage);
@@ -179,7 +184,6 @@ export class Handlers {
       if (error instanceof McpError) {
         throw error;
       }
-
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       console.error("API Error:", errorMessage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -62,14 +63,15 @@ class AhaMcp {
       tools: [
         {
           name: "get_record",
-          description: "Get an Aha! feature or requirement by reference number",
+          description:
+            "Get an Aha! feature, requirement, or epic by reference number",
           inputSchema: {
             type: "object",
             properties: {
               reference: {
                 type: "string",
                 description:
-                  "Reference number (e.g., DEVELOP-123 or ADT-123-1)",
+                  "Reference number (e.g., DEVELOP-123, ADT-123-1, or DCOMMS-E-157)",
               },
             },
             required: ["reference"],
@@ -107,7 +109,8 @@ class AhaMcp {
               },
               searchableType: {
                 type: "string",
-                description: "Type of document to search for (e.g., Page)",
+                description:
+                  "Type of document to search for (e.g., Page, Epic, Feature)",
                 default: "Page",
               },
             },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,57 +1,68 @@
 export const getPageQuery = `
-  query GetPage($id: ID!, $includeParent: Boolean!) {
-    page(id: $id) {
+query GetPage($id: ID!, $includeParent: Boolean!) {
+  page(id: $id) {
+    name
+    description {
+      markdownBody
+    }
+    children {
       name
-      description {
-        markdownBody
-      }
-      children {
-        name
-        referenceNum
-      }
-      parent @include(if: $includeParent) {
-        name
-        referenceNum
-      }
+      referenceNum
+    }
+    parent @include(if: $includeParent) {
+      name
+      referenceNum
     }
   }
+}
 `;
 
 export const getFeatureQuery = `
-  query GetFeature($id: ID!) {
-    feature(id: $id) {
-      name
-      description {
-        markdownBody
-      }
+query GetFeature($id: ID!) {
+  feature(id: $id) {
+    name
+    description {
+      markdownBody
     }
   }
+}
 `;
 
 export const getRequirementQuery = `
-  query GetRequirement($id: ID!) {
-    requirement(id: $id) {
-      name
-      description {
-        markdownBody
-      }
+query GetRequirement($id: ID!) {
+  requirement(id: $id) {
+    name
+    description {
+      markdownBody
     }
   }
+}
+`;
+
+export const getEpicQuery = `
+query GetEpic($id: ID!) {
+  epic(id: $id) {
+    name
+    description {
+      markdownBody
+    }
+  }
+}
 `;
 
 export const searchDocumentsQuery = `
-  query SearchDocuments($query: String!, $searchableType: [String!]!) {
-    searchDocuments(filters: {query: $query, searchableType: $searchableType}) {
-      nodes {
-        name
-        url
-        searchableId
-        searchableType
-      }
-      currentPage
-      totalCount
-      totalPages
-      isLastPage
+query SearchDocuments($query: String!, $searchableType: [String!]!) {
+  searchDocuments(filters: {query: $query, searchableType: $searchableType}) {
+    nodes {
+      name
+      url
+      searchableId
+      searchableType
     }
+    currentPage
+    totalCount
+    totalPages
+    isLastPage
   }
+}
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,10 @@ export interface RequirementResponse {
   requirement: Record;
 }
 
+export interface EpicResponse {
+  epic: Record;
+}
+
 export interface PageResponse {
   page: {
     name: string;
@@ -34,6 +38,7 @@ export interface PageResponse {
 export const FEATURE_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)$/;
 export const REQUIREMENT_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)-(\d+)$/;
 export const NOTE_REF_REGEX = /^([A-Z][A-Z0-9]*)-N-(\d+)$/;
+export const EPIC_REF_REGEX = /^([A-Z][A-Z0-9]*)-E-(\d+)$/;
 
 export interface SearchNode {
   name: string | null;


### PR DESCRIPTION
## Summary

`get_record` currently supports features (`DEVELOP-123`) and requirements
(`ADT-123-1`) but rejects epic references (`DCOMMS-E-157`) with an
`InvalidParams` error. `search_documents` with `searchableType: "Epic"`
already works and returns valid epic references — but there's no way to
fetch their content.

This PR adds epic support to `get_record` so references like `DCOMMS-E-157`
and `CLAIMST-E-474` resolve to their name and description body.

## Changes

- `src/types.ts` — add `EPIC_REF_REGEX` and `EpicResponse` interface
- `src/queries.ts` — add `getEpicQuery` using the `epic(id)` GraphQL resolver
- `src/handlers.ts` — import epic types/query, add epic branch in `handleGetRecord`
- `src/index.ts` — update `get_record` description to mention epics

## Notes

- The epic regex does not conflict with existing patterns:
  - Features: `PRODUCT-123` (digits only after hyphen)
  - Requirements: `PRODUCT-123-1` (two numeric segments)
  - Epics: `PRODUCT-E-123` (literal `E` segment)
- No breaking changes — existing feature and requirement behavior is unchanged
- `search_documents` with `searchableType: "Epic"` already works; this
  closes the gap between finding an epic and reading it

Closes #20