### PR TITLE
docs: note repository is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # aha-mcp
 
+> [!IMPORTANT]
+> This repository is obsolete and will be archived. Use the supported [Aha! remote MCP server](https://support.aha.io/aha-develop/integrations/mcp-server/remote-mcp-server~7611250482619899159) instead.
+>
+> The remote MCP server connects directly from your AI tool to `https://[your-aha-domain].aha.io/api/v1/mcp`, uses your Aha! permissions, and has broader capabilities, including creating and editing records. This package only contains read-only tools and should not be used for new setups.
+
 Model Context Protocol (MCP) server for accessing Aha! records through the MCP. This integration enables seamless interaction with Aha! features, requirements, and pages directly through the Model Context Protocol.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # aha-mcp
 
 > [!IMPORTANT]
-> This repository is obsolete and will be archived. Use the supported [Aha! remote MCP server](https://support.aha.io/aha-develop/integrations/mcp-server/remote-mcp-server~7611250482619899159) instead.
+> This repository is replaced by the hosted [Aha! remote MCP server](https://support.aha.io/aha-develop/integrations/mcp-server/remote-mcp-server~7611250482619899159) instead.
 >
-> The remote MCP server connects directly from your AI tool to `https://[your-aha-domain].aha.io/api/v1/mcp`, uses your Aha! permissions, and has broader capabilities, including creating and editing records. This package only contains read-only tools and should not be used for new setups.
+> The remote MCP server connects directly from your AI tool to `https://[your-aha-domain].aha.io/api/v1/mcp`, uses your Aha! permissions, and has broader capabilities, including creating and editing records. 
 
 Model Context Protocol (MCP) server for accessing Aha! records through the MCP. This integration enables seamless interaction with Aha! features, requirements, and pages directly through the Model Context Protocol.
 


### PR DESCRIPTION
## Summary
- Add a prominent README notice that this repository is obsolete and will be archived.
- Direct users to the supported Aha! remote MCP server documentation.
- Clarify that the remote MCP server has broader capabilities, including creating and editing records, while this package only contains read-only tools.

<img width="1204" height="339" alt="image" src="https://github.com/user-attachments/assets/9a8787bc-92d1-42ab-8b31-a86fb3565c8b" />
